### PR TITLE
Allow specifying target version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gocd-yaml-config-plugin
 
-[GoCD](go.cd) server plugin to keep **pipelines** and **environments**
+[GoCD](https://www.gocd.org) server plugin to keep **pipelines** and **environments**
 configuration in source-control in [YAML](http://www.yaml.org/).
 See [this document](https://docs.gocd.org/current/advanced_usage/pipelines_as_code.html)
 to find out what are GoCD configuration repositories.
@@ -23,8 +23,9 @@ so you can explain why pipeline/environment it is configured like this.
 
 ## Setup
 
-Download plugin from releases page and place in your Go server (`>= 16.7.0`)
-in `plugins/external` directory.
+If you're using GoCD version *older than 17.8.0*, you need to install the plugin in the GoCD server. Download it from
+[the releases page](https://github.com/tomzo/gocd-yaml-config-plugin/releases) and place it on the GoCD server in
+`plugins/external` [directory](https://docs.gocd.org/current/extension_points/plugin_user_guide.html).
 
 Add `config-repos` element right above first `<pipelines />`. Then you can
 add any number of YAML configuration repositories as such:
@@ -104,7 +105,7 @@ By default GoCD configuration files should end with `.gocd.yaml`.
 
 # Specification
 
-See [official GoCD XML configuration reference](https://docs.go.cd/current/configuration/configuration_reference.html)
+See [official GoCD XML configuration reference](https://docs.gocd.org/current/configuration/configuration_reference.html)
 for details about each element. Below is a reference of format supported by this plugin.
 Feel free to improve it!
 
@@ -143,7 +144,7 @@ Feel free to improve it!
 
 # Pipeline
 
-A minimal [pipeline](https://docs.go.cd/current/configuration/configuration_reference.html#pipeline) configuration must contain:
+A minimal [pipeline](https://docs.gocd.org/current/configuration/configuration_reference.html#pipeline) configuration must contain:
  * pipeline name - as a key in hash
  * [materials](#materials) - a **hash**
  * [stages](#stage) - a **list**
@@ -195,8 +196,8 @@ pipe2:
 ```
 
 Please note:
- * [templates](https://docs.go.cd/current/configuration/configuration_reference.html#templates) are not supported
- * [parameters](https://docs.go.cd/current/configuration/configuration_reference.html#params) are not supported
+ * [templates](https://docs.gocd.org/current/configuration/configuration_reference.html#templates) are not supported
+ * [parameters](https://docs.gocd.org/current/configuration/configuration_reference.html#params) are not supported
  * pipeline declares a group to which it belongs
 
 ### Tracking tool
@@ -215,7 +216,7 @@ timer:
   only_on_changes: yes
 ```
 
-See [XML reference](https://docs.go.cd/current/configuration/configuration_reference.html#timer) for more information.
+See [XML reference](https://docs.gocd.org/current/configuration/configuration_reference.html#timer) for more information.
 
 ## Stage
 
@@ -254,7 +255,7 @@ test:
 
 ### Approval
 
-Stage can have [approval](https://docs.go.cd/current/configuration/configuration_reference.html#approval),
+Stage can have [approval](https://docs.gocd.org/current/configuration/configuration_reference.html#approval),
  which is `success` by default. There are 2 ways to declare approval:
 ```yaml
 approval: manual
@@ -271,7 +272,7 @@ approval:
 
 ## Job
 
-[Job](https://docs.go.cd/current/configuration/configuration_reference.html#job) is a hash starting with jobs name:
+[Job](https://docs.gocd.org/current/configuration/configuration_reference.html#job) is a hash starting with jobs name:
 
 ```yaml
 test:
@@ -311,7 +312,7 @@ Available in GoCD server since v16.12.0, yaml plugin 0.4.0.
 
 ### Run many instances
 
-Part of job object can be [number of job to runs](https://docs.go.cd/current/advanced_usage/admin_spawn_multiple_jobs.html):
+Part of job object can be [number of job to runs](https://docs.gocd.org/current/advanced_usage/admin_spawn_multiple_jobs.html):
 ```yaml
 run_instances: 7
 ```
@@ -323,7 +324,7 @@ run_instances: all
 ### Tabs
 
 Tabs are a hash with `<tab-name>: <path>` pairs.
-Path should exist in Go servers artifacts.
+Path should exist in GoCD servers artifacts.
 ```yaml
 tabs:
   tests: test-reports/index.html
@@ -364,7 +365,7 @@ Above configuration declares `build` **stage** with `build` **job** which execut
 
 ### Git
 
-Minimal configuration of a [**git** pipeline material](https://docs.go.cd/current/configuration/configuration_reference.html#git):
+Minimal configuration of a [**git** pipeline material](https://docs.gocd.org/current/configuration/configuration_reference.html#git):
  * material name is `mygit`
  * git repository url is `http://example.com/mygit.git`
 
@@ -393,7 +394,7 @@ gitMaterial1:
   shallow_clone: true
 ```
 
-Since Go `>= 16.7.0` whitelist is also supported,
+Since GoCD `>= 16.7.0` whitelist is also supported,
 you can specify `whitelist` **instead** of `blacklist`, as such
 ```yaml
 gitMaterial1:
@@ -405,7 +406,7 @@ gitMaterial1:
 
 ### Svn
 
-For details about each option, see [GoCD XML reference](https://docs.go.cd/current/configuration/configuration_reference.html#svn)
+For details about each option, see [GoCD XML reference](https://docs.gocd.org/current/configuration/configuration_reference.html#svn)
 ```yaml
 svnMaterial1:
   svn: "http://svn"
@@ -680,7 +681,7 @@ testing:
 
 ### Environment variables
 
-[Environment variables](https://docs.go.cd/current/configuration/configuration_reference.html#environmentvariables)
+[Environment variables](https://docs.gocd.org/current/configuration/configuration_reference.html#environmentvariables)
  can be declared in **Environments, Pipelines, Stages and Jobs**.
 
 In YAML you have 2 keywords for *secure* (encrypted) variables and standard variables.
@@ -773,6 +774,6 @@ Run all tests and create a ready to use jar
 ## Tests structure
 
 There are [examples of yaml partials](src/test/resources/parts) and
- their resulting json to be sent to Go server. If something is not working right
+ their resulting json to be sent to GoCD server. If something is not working right
  we can always add a new case covering exact yaml that user has and json that we
  expect on server side.

--- a/src/main/java/cd/go/plugin/config/yaml/AntDirectoryScanner.java
+++ b/src/main/java/cd/go/plugin/config/yaml/AntDirectoryScanner.java
@@ -10,7 +10,7 @@ public class AntDirectoryScanner implements ConfigDirectoryScanner {
     public String[] getFilesMatchingPattern(File directory, String pattern) {
         DirectoryScanner scanner = new DirectoryScanner();
         scanner.setBasedir(directory);
-        scanner.setIncludes(new String[]{pattern});
+        scanner.setIncludes(pattern.trim().split(" *, *"));
         scanner.scan();
         return scanner.getIncludedFiles();
     }

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -106,6 +106,7 @@ public class YamlConfigPlugin implements GoPlugin {
             String[] files = scanner.getFilesMatchingPattern(baseDir, pattern);
             JsonConfigCollection config = parser.parseFiles(baseDir, files);
 
+            config.updateTargetVersionFromFiles();
             JsonObject responseJsonObject = config.getJsonObject();
 
             return DefaultGoPluginApiResponse.success(gson.toJson(responseJsonObject));

--- a/src/main/java/cd/go/plugin/config/yaml/YamlFileParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlFileParser.java
@@ -32,7 +32,7 @@ public class YamlFileParser {
             } catch (YamlReader.YamlReaderException ex) {
                 collection.addError(ex.getMessage() , file);
             } catch (FileNotFoundException ex) {
-                collection.addError("File matching Go YAML pattern disappeared", file);
+                collection.addError("File matching GoCD YAML pattern disappeared", file);
             } catch (IOException ex) {
                 collection.addError(ex.getMessage() +" : "+ ex.getCause().getMessage() + " : ", file);
             } finally {

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
@@ -15,6 +15,7 @@ public class PipelineTransform {
     private static final String JSON_PIPELINE_GROUP_FIELD = "group";
     private static final String JSON_PIPELINE_LABEL_TEMPLATE_FIELD = "label_template";
     private static final String JSON_PIPELINE_PIPE_LOCKING_FIELD = "enable_pipeline_locking";
+    private static final String JSON_PIPELINE_LOCK_BEHAVIOR_FIELD = "lock_behavior";
     private static final String JSON_PIPELINE_MINGLE_FIELD = "mingle";
     private static final String JSON_PIPELINE_TRACKING_TOOL_FIELD = "tracking_tool";
     private static final String JSON_PIPELINE_TIMER_FIELD = "timer";
@@ -24,6 +25,7 @@ public class PipelineTransform {
     private static final String YAML_PIPELINE_GROUP_FIELD = "group";
     private static final String YAML_PIPELINE_LABEL_TEMPLATE_FIELD = "label_template";
     private static final String YAML_PIPELINE_PIPE_LOCKING_FIELD = "locking";
+    private static final String YAML_PIPELINE_LOCK_BEHAVIOR_FIELD = "lock_behavior";
     private static final String YAML_PIPELINE_MINGLE_FIELD = "mingle";
     private static final String YAML_PIPELINE_TRACKING_TOOL_FIELD = "tracking_tool";
     private static final String YAML_PIPELINE_TIMER_FIELD = "timer";
@@ -57,6 +59,7 @@ public class PipelineTransform {
         addOptionalString(pipeline, pipeMap, JSON_PIPELINE_GROUP_FIELD, YAML_PIPELINE_GROUP_FIELD);
         addOptionalString(pipeline, pipeMap, JSON_PIPELINE_LABEL_TEMPLATE_FIELD, YAML_PIPELINE_LABEL_TEMPLATE_FIELD);
         addOptionalBoolean(pipeline, pipeMap, JSON_PIPELINE_PIPE_LOCKING_FIELD, YAML_PIPELINE_PIPE_LOCKING_FIELD);
+        addOptionalString(pipeline, pipeMap, JSON_PIPELINE_LOCK_BEHAVIOR_FIELD, YAML_PIPELINE_LOCK_BEHAVIOR_FIELD);
 
         addOptionalObject(pipeline, pipeMap, JSON_PIPELINE_TRACKING_TOOL_FIELD, YAML_PIPELINE_TRACKING_TOOL_FIELD);
         addOptionalObject(pipeline, pipeMap, JSON_PIPELINE_MINGLE_FIELD, YAML_PIPELINE_MINGLE_FIELD);

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/RootTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/RootTransform.java
@@ -55,8 +55,10 @@ public class RootTransform {
                                 String.format("Failed to parse environment %s; %s", env.getKey(), ex.getMessage()), location));
                     }
                 }
+            } else if ("format_version".equalsIgnoreCase(pe.getKey())) {
+                partialConfig.updateFormatVersionFound(Integer.valueOf((String) pe.getValue()));
             } else if (!"common".equalsIgnoreCase(pe.getKey()))
-                throw new YamlConfigException(pe.getKey() + " is invalid, expected pipelines, environments, or common");
+                throw new YamlConfigException(pe.getKey() + " is invalid, expected format_version, pipelines, environments, or common");
         }
         return partialConfig;
     }

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -1,5 +1,5 @@
 <div class="form_item_block">
     <label>Go YAML files global pattern:</label>
-    <input type="text" ng-model="file_pattern" ng-required="false"/>
+    <input type="text" ng-model="file_pattern" ng-required="false" placeholder="**/*.gocd.yaml" />
     <span class="form_error" ng-show="GOINPUTNAME[file_pattern].$error.server">{{ GOINPUTNAME[file_pattern].$error.server }}</span>
 </div>

--- a/src/test/java/cd/go/plugin/config/yaml/AntDirectoryScannerTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/AntDirectoryScannerTest.java
@@ -1,0 +1,87 @@
+package cd.go.plugin.config.yaml;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class AntDirectoryScannerTest {
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    private AntDirectoryScanner scanner;
+
+    @Before
+    public void setUp() throws Exception {
+        scanner = new AntDirectoryScanner();
+    }
+
+    @Test
+    public void shouldMatchSimplePattern() throws Exception {
+        tempDir.newFile("abc.xml");
+        tempDir.newFile("def.xml");
+        tempDir.newFile("ghi.txt");
+
+        String[] xmlFilesOnly = scanner.getFilesMatchingPattern(tempDir.getRoot(), "*.xml");
+
+        assertThat(xmlFilesOnly.length, is(2));
+        assertThat(asList(xmlFilesOnly), hasItems("abc.xml", "def.xml"));
+    }
+
+    @Test
+    public void shouldMatchPatternInDirectory() throws Exception {
+        tempDir.newFolder("1", "a");
+        tempDir.newFolder("2", "d");
+        tempDir.newFolder("3");
+        tempDir.newFolder("4");
+
+        tempDir.newFile("1/a/abc.xml");
+        tempDir.newFile("2/d/def.xml");
+        tempDir.newFile("3/ghi.xml");
+        tempDir.newFile("4/jkl.txt");
+        tempDir.newFile("mno.txt");
+        tempDir.newFile("pqr.xml");
+
+        String[] xmlFilesOnly = scanner.getFilesMatchingPattern(tempDir.getRoot(), "**/*.xml");
+
+        assertThat(xmlFilesOnly.length, is(4));
+        assertThat(asList(xmlFilesOnly), hasItems("1/a/abc.xml", "2/d/def.xml", "3/ghi.xml", "pqr.xml"));
+    }
+
+    @Test
+    public void shouldIgnoreSpacesAroundThePattern() throws Exception {
+        tempDir.newFile("def.xml");
+        tempDir.newFile("ghi.txt");
+
+        String[] xmlFilesOnly = scanner.getFilesMatchingPattern(tempDir.getRoot(), " *.xml ");
+
+        assertThat(xmlFilesOnly.length, is(1));
+        assertThat(asList(xmlFilesOnly), hasItems("def.xml"));
+    }
+
+    @Test
+    public void shouldAcceptMultiplePatternsSeparatedByComma() throws Exception {
+        tempDir.newFolder("1", "a");
+        tempDir.newFolder("2", "d");
+        tempDir.newFolder("3");
+        tempDir.newFolder("4");
+
+        tempDir.newFile("1/a/abc.xml");
+        tempDir.newFile("2/d/def.gif");
+        tempDir.newFile("3/ghi.xml");
+        tempDir.newFile("4/jkl.txt");
+        tempDir.newFile("mno.jpg");
+        tempDir.newFile("4/pqr.jpg");
+        tempDir.newFile("stu.xml");
+
+        String[] xmlFilesOnly = scanner.getFilesMatchingPattern(tempDir.getRoot(), "**/*.xml, **/*.gif, *.jpg");
+
+        assertThat(xmlFilesOnly.length, is(5));
+        assertThat(asList(xmlFilesOnly), hasItems("1/a/abc.xml", "2/d/def.gif", "3/ghi.xml", "mno.jpg", "stu.xml"));
+    }
+}

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformTest.java
@@ -38,6 +38,11 @@ public class PipelineTransformTest {
         testTransform("rich.pipe");
     }
 
+    @Test
+    public void shouldTransformRichPipeline2() throws IOException {
+        testTransform("lock_behavior.pipe");
+    }
+
     private void testTransform(String caseFile) throws IOException {
         testTransform(caseFile, caseFile);
     }

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/RootTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/RootTransformTest.java
@@ -3,6 +3,8 @@ package cd.go.plugin.config.yaml.transforms;
 import cd.go.plugin.config.yaml.JsonConfigCollection;
 import cd.go.plugin.config.yaml.YamlConfigException;
 import com.esotericsoftware.yamlbeans.YamlReader;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,6 +52,13 @@ public class RootTransformTest {
         assertThat(collection.getJsonObject().get("pipelines").getAsJsonArray().size(), is(1));
     }
 
+    @Test
+    public void shouldRecognizeAndUpdateVersion() throws Exception {
+        assertTargetVersion(readRootYaml("version_not_present").getJsonObject(), 1);
+        assertTargetVersion(readRootYaml("version_1").getJsonObject(), 1);
+        assertTargetVersion(readRootYaml("version_2").getJsonObject(), 2);
+    }
+
     @Test(expected = YamlReader.YamlReaderException.class)
     public void shouldNotTransformRootWhenYAMLHasDuplicateKeys() throws IOException {
         readRootYaml("duplicate.materials.pipe");
@@ -58,5 +67,10 @@ public class RootTransformTest {
 
     private JsonConfigCollection readRootYaml(String caseFile) throws IOException {
         return rootTransform.transform(readYamlObject("parts/roots/" + caseFile + ".yaml"), "test code");
+    }
+
+    private void assertTargetVersion(JsonObject jsonObject, int expectedVersion) {
+        assertThat(jsonObject.get("target_version") instanceof JsonPrimitive, is(true));
+        assertThat(jsonObject.getAsJsonPrimitive("target_version").getAsInt(), is(expectedVersion));
     }
 }

--- a/src/test/resources/examples.out/README.md
+++ b/src/test/resources/examples.out/README.md
@@ -1,2 +1,2 @@
-This directory contains JSON responses that would be sent to Go server after parsing
+This directory contains JSON responses that would be sent to GoCD server after parsing
 contents of files in [examples](../examples).

--- a/src/test/resources/parts/lock_behavior.pipe.json
+++ b/src/test/resources/parts/lock_behavior.pipe.json
@@ -1,0 +1,13 @@
+{
+  "group": "group1",
+  "name": "pipe2",
+  "lock_behavior": "lockOnFailure",
+  "materials": [
+    null,
+    null
+  ],
+  "stages": [
+    null,
+    null
+  ]
+}

--- a/src/test/resources/parts/lock_behavior.pipe.yaml
+++ b/src/test/resources/parts/lock_behavior.pipe.yaml
@@ -1,0 +1,10 @@
+pipe2:
+  group: group1
+  lock_behavior: "lockOnFailure"
+  environment_variables: null
+  materials:
+    foo:
+    bar:
+  stages:
+    - null
+    - null

--- a/src/test/resources/parts/roots/version_1.yaml
+++ b/src/test/resources/parts/roots/version_1.yaml
@@ -1,0 +1,20 @@
+format_version: 1
+environments:
+  first:
+    pipelines:
+      - pipe1
+pipelines:
+  pipe1:
+    group: simple
+    materials:
+      mygit:
+        git: http://test.example.git
+    stages:
+      - build:
+          jobs:
+            job1:
+              tasks:
+               - exec:
+                  command: make
+                  arguments:
+                    - "abc"

--- a/src/test/resources/parts/roots/version_2.yaml
+++ b/src/test/resources/parts/roots/version_2.yaml
@@ -1,0 +1,20 @@
+format_version: 2
+environments:
+  first:
+    pipelines:
+      - pipe1
+pipelines:
+  pipe1:
+    group: simple
+    materials:
+      mygit:
+        git: http://test.example.git
+    stages:
+      - build:
+          jobs:
+            job1:
+              tasks:
+               - exec:
+                  command: make
+                  arguments:
+                    - "abc"

--- a/src/test/resources/parts/roots/version_not_present.yaml
+++ b/src/test/resources/parts/roots/version_not_present.yaml
@@ -1,0 +1,19 @@
+environments:
+  first:
+    pipelines:
+      - pipe1
+pipelines:
+  pipe1:
+    group: simple
+    materials:
+      mygit:
+        git: http://test.example.git
+    stages:
+      - build:
+          jobs:
+            job1:
+              tasks:
+               - exec:
+                  command: make
+                  arguments:
+                    - "abc"


### PR DESCRIPTION
Equivalent of https://github.com/tomzo/gocd-json-config-plugin/pull/12 for the yaml plugin.

Does this:

1. Updates README: Mostly Go => GoCD and *.go.cd to *.gocd.org.
2. Accept multiple patterns in the settings file. Old (single) patterns work too.
3. Allow specifying target version in the YAML.
4. Accept `lock_behavior` in the YAML.

It'll be like this, for every file:

```
format_version: 2
environments:
  env1: ...
  env2: ...
pipelines:
  pipe1:
      lock_behavior: "lockOnFailure"
      ...
```