### PR TITLE
Preserve order of pipelines within a group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ hs_err_pid*
 /.gradle/
 /.idea/
 /build/
+/out/
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
     compile group: 'org.apache.ant', name: 'ant', version: '1.7.1'
-    compile group: 'com.github.sanjusoftware', name: 'yamlbeans', version: '1.11'
+    compile group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version: '1.13'
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/EnvironmentsTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/EnvironmentsTransform.java
@@ -30,7 +30,7 @@ public class EnvironmentsTransform {
         JsonObject envJson = new JsonObject();
         envJson.addProperty(JSON_ENV_NAME_FIELD, envName);
         Object envObj = env.getValue();
-        if ("".equals(envObj))
+        if (envObj == null)
             return envJson;
         if (!(envObj instanceof Map))
             throw new YamlConfigException("Expected environment to be a hash");

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/RootTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/RootTransform.java
@@ -31,7 +31,7 @@ public class RootTransform {
         Map<String, Object> rootMap = (Map<String, Object>) rootObj;
         for (Map.Entry<String, Object> pe : rootMap.entrySet()) {
             if ("pipelines".equalsIgnoreCase(pe.getKey())) {
-                if ("".equals(pe.getValue()))
+                if (pe.getValue() == null)
                     continue;
                 Map<String, Object> pipelines = (Map<String, Object>) pe.getValue();
                 for (Map.Entry<String, Object> pipe : pipelines.entrySet()) {
@@ -44,7 +44,7 @@ public class RootTransform {
                     }
                 }
             } else if ("environments".equalsIgnoreCase(pe.getKey())) {
-                if ("".equals(pe.getValue()))
+                if (pe.getValue() == null)
                     continue;
                 Map<String, Object> environments = (Map<String, Object>) pe.getValue();
                 for (Map.Entry<String, Object> env : environments.entrySet()) {

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/TaskTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/TaskTransform.java
@@ -49,6 +49,10 @@ public class TaskTransform {
         JsonObject taskJson = new JsonObject();
 
         String taskType = taskEntry.getKey();
+        if (taskEntry.getValue() == null) {
+            taskJson.addProperty(JSON_TASK_TYPE_FIELD, taskType);
+            return taskJson;
+        }
         if (taskEntry.getValue() instanceof String) {
             if (taskType.equalsIgnoreCase("script")) {
                 taskJson.addProperty(JSON_TASK_TYPE_FIELD, "plugin");
@@ -62,10 +66,6 @@ public class TaskTransform {
                 pluginConfig.addProperty("version", "1");
                 taskJson.add(JSON_PLUGIN_CONFIGURATION_FIELD, config);
                 taskJson.add(JSON_TASK_PLUGIN_CONFIGURATION_FIELD, pluginConfig);
-                return taskJson;
-            }
-            if ("".equals(taskEntry.getValue())) {
-                taskJson.addProperty(JSON_TASK_TYPE_FIELD, taskType);
                 return taskJson;
             }
         }

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/RootTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/RootTransformTest.java
@@ -3,6 +3,7 @@ package cd.go.plugin.config.yaml.transforms;
 import cd.go.plugin.config.yaml.JsonConfigCollection;
 import cd.go.plugin.config.yaml.YamlConfigException;
 import com.esotericsoftware.yamlbeans.YamlReader;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.junit.Before;
@@ -57,6 +58,22 @@ public class RootTransformTest {
         assertTargetVersion(readRootYaml("version_not_present").getJsonObject(), 1);
         assertTargetVersion(readRootYaml("version_1").getJsonObject(), 1);
         assertTargetVersion(readRootYaml("version_2").getJsonObject(), 2);
+    }
+    
+    @Test
+    public void shouldPreserveOrderOfPipelines() throws IOException {
+        MaterialTransform materialTransform = mock(MaterialTransform.class);
+        StageTransform stageTransform = mock(StageTransform.class);
+        EnvironmentVariablesTransform environmentTransform = mock(EnvironmentVariablesTransform.class);
+        ParameterTransform parameterTransform = mock(ParameterTransform.class);
+        pipelineTransform = new PipelineTransform(materialTransform, stageTransform, environmentTransform, parameterTransform);
+        rootTransform = new RootTransform(pipelineTransform, environmentsTransform);
+        
+        JsonConfigCollection collection = readRootYaml("pipeline_order");
+        JsonArray pipelines = collection.getJsonObject().get("pipelines").getAsJsonArray();
+        assertThat(pipelines.get(0).getAsJsonObject().get("name").getAsString(), is("pipe1"));
+        assertThat(pipelines.get(1).getAsJsonObject().get("name").getAsString(), is("pipe2"));
+        assertThat(pipelines.get(2).getAsJsonObject().get("name").getAsString(), is("pipe3"));
     }
 
     @Test(expected = YamlReader.YamlReaderException.class)

--- a/src/test/resources/parts/roots/pipeline_order.yaml
+++ b/src/test/resources/parts/roots/pipeline_order.yaml
@@ -1,0 +1,24 @@
+environments:
+  env1:
+    pipelines:
+      - pipe1
+
+pipelines:
+  pipe1:
+    group: simple
+    materials:
+      mygit:
+    stages:
+      - null
+  pipe2:
+    group: simple
+    materials:
+      mygit:
+    stages:
+      - null
+  pipe3:
+    group: simple
+    materials:
+      mygit:
+    stages:
+      - null


### PR DESCRIPTION
Fixes #4.

I couldn't find a reason why the sanjusoftware fork of yamlbeans was being used - perhaps the original issue has since been fixed in the main yamlbeans releases?
I did have to change a small number of conditionals in existing transforms, as a key without a value is read as `null` instead of an empty string by this yamlbeans version. Otherwise, the ordering comes for free and I've added a test to verify it.