### PR TITLE
Use valid pipeline example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ A minimal [pipeline](https://docs.gocd.org/current/configuration/configuration_r
 
 ```yaml
 mypipe:
+  group: mygroup
   materials:
     mygit:
       git: http://example.com/mygit.git


### PR DESCRIPTION
The `group` attribute must be specified for a pipeline. Bit of a pain to copy paste this only to get an error thrown.