### PR TITLE
weird pipeline config/progression need

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -24,14 +24,17 @@ import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse
 public class YamlConfigPlugin implements GoPlugin {
     public static final String GET_PLUGIN_SETTINGS = "go.processor.plugin-settings.get";
     private static final String DISPLAY_NAME_FILE_PATTERN = "Go YAML files pattern";
+    private static final String DISPLAY_NAME_TAG = "Go YAML pipeline tag";
     private static final String PLUGIN_SETTINGS_FILE_PATTERN = "file_pattern";
+    private static final String PLUGIN_SETTINGS_TAG = "pipeline_tag";
     private static final String MISSING_DIRECTORY_MESSAGE = "directory property is missing in parse-directory request";
     private static final String EMPTY_REQUEST_BODY_MESSAGE = "Request body cannot be null or empty";
-    private static final String PLUGIN_ID = "yaml.config.plugin";
+    private static final String PLUGIN_ID = "yaml-tag.config.plugin";
     public static final String PLUGIN_SETTINGS_GET_CONFIGURATION = "go.plugin-settings.get-configuration";
     public static final String PLUGIN_SETTINGS_GET_VIEW = "go.plugin-settings.get-view";
     public static final String PLUGIN_SETTINGS_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";
     public static final String DEFAULT_FILE_PATTERN = "**/*.gocd.yaml,**/*.gocd.yml";
+    public static final String DEFAULT_TAG = "master";
 
     private static Logger LOGGER = Logger.getLoggerFor(YamlConfigPlugin.class);
 
@@ -152,6 +155,7 @@ public class YamlConfigPlugin implements GoPlugin {
     private GoPluginApiResponse handleGetPluginSettingsConfiguration() {
         Map<String, Object> response = new HashMap<String, Object>();
         response.put(PLUGIN_SETTINGS_FILE_PATTERN, createField(DISPLAY_NAME_FILE_PATTERN, DEFAULT_FILE_PATTERN, false, false, "0"));
+        response.put(PLUGIN_SETTINGS_TAG, createField(DISPLAY_NAME_TAG, DEFAULT_TAG, false, false, "1"));
         return renderJSON(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response);
     }
 

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -115,7 +115,6 @@ public class YamlConfigPlugin implements GoPlugin {
                         return badRequest("Config repo configuration has invalid key=" + key);
                 }
             }
-            LOGGER.warn("the pipeline tag is " + pipelineTag);
             YamlFileParser parser = new YamlFileParser();
             PluginSettings settings = getPluginSettings();
             ConfigDirectoryScanner scanner = new AntDirectoryScanner();

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -29,7 +29,7 @@ public class YamlConfigPlugin implements GoPlugin {
     private static final String PLUGIN_SETTINGS_PIPELINE_TAG = "pipeline_tag";
     private static final String MISSING_DIRECTORY_MESSAGE = "directory property is missing in parse-directory request";
     private static final String EMPTY_REQUEST_BODY_MESSAGE = "Request body cannot be null or empty";
-    private static final String PLUGIN_ID = "yaml-tag.config.plugin";
+    private static final String PLUGIN_ID = "yaml.config.plugin";
     public static final String PLUGIN_SETTINGS_GET_CONFIGURATION = "go.plugin-settings.get-configuration";
     public static final String PLUGIN_SETTINGS_GET_VIEW = "go.plugin-settings.get-view";
     public static final String PLUGIN_SETTINGS_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";

--- a/src/main/java/cd/go/plugin/config/yaml/YamlFileParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlFileParser.java
@@ -17,7 +17,7 @@ public class YamlFileParser {
         this.rootTransform = rootTransform;
     }
 
-    public JsonConfigCollection parseFiles(File baseDir, String[] files) {
+    public JsonConfigCollection parseFiles(File baseDir, String[] files, String pipelineTag) {
         JsonConfigCollection collection = new JsonConfigCollection();
         for (String file : files) {
             InputStream inputStream = null;
@@ -27,7 +27,7 @@ public class YamlFileParser {
                 config.setAllowDuplicates(false);
                 YamlReader reader = new YamlReader(new InputStreamReader(inputStream), config);
                 Object rootObject = reader.read();
-                JsonConfigCollection filePart = rootTransform.transform(rootObject, file);
+                JsonConfigCollection filePart = rootTransform.transform(rootObject, file, pipelineTag);
                 collection.append(filePart);
             } catch (YamlReader.YamlReaderException ex) {
                 collection.addError(ex.getMessage() , file);

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
@@ -24,6 +24,7 @@ public class PipelineTransform {
     private static final String JSON_PIPELINE_MATERIALS_FIELD = "materials";
     private static final String JSON_PIPELINE_STAGES_FIELD = "stages";
 
+    private static final String YAML_PIPELINE_TAG_FIELD = "tag";
     private static final String YAML_PIPELINE_GROUP_FIELD = "group";
     private static final String YAML_PIPELINE_TEMPLATE_FIELD = "template";
     private static final String YAML_PIPELINE_LABEL_TEMPLATE_FIELD = "label_template";
@@ -55,11 +56,16 @@ public class PipelineTransform {
         throw new RuntimeException("expected pipeline hash to have 1 item");
     }
 
-    public JsonObject transform(Map.Entry<String, Object> entry) {
+    public JsonObject transform(Map.Entry<String, Object> entry, String pipelineTag) {
         String pipelineName = entry.getKey();
         JsonObject pipeline = new JsonObject();
         pipeline.addProperty(JSON_PIPELINE_NAME_FIELD, pipelineName);
         Map<String, Object> pipeMap = (Map<String, Object>) entry.getValue();
+
+        //we need to skip this as it is not tagged for us.
+        if(pipelineTag != null && !pipelineTag.equals(getOptionalString(pipeMap,YAML_PIPELINE_TAG_FIELD))) {
+            return null;
+        }
 
         addOptionalString(pipeline, pipeMap, JSON_PIPELINE_GROUP_FIELD, YAML_PIPELINE_GROUP_FIELD);
         addOptionalString(pipeline, pipeMap, JSON_PIPELINE_TEMPLATE_FIELD, YAML_PIPELINE_TEMPLATE_FIELD);

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/RootTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/RootTransform.java
@@ -26,7 +26,7 @@ public class RootTransform {
         this.environmentsTransform = environmentsTransform;
     }
 
-    public JsonConfigCollection transform(Object rootObj, String location) {
+    public JsonConfigCollection transform(Object rootObj, String location, String pipelineTag) {
         JsonConfigCollection partialConfig = new JsonConfigCollection();
         Map<String, Object> rootMap = (Map<String, Object>) rootObj;
         for (Map.Entry<String, Object> pe : rootMap.entrySet()) {
@@ -36,8 +36,10 @@ public class RootTransform {
                 Map<String, Object> pipelines = (Map<String, Object>) pe.getValue();
                 for (Map.Entry<String, Object> pipe : pipelines.entrySet()) {
                     try {
-                        JsonElement jsonPipeline = pipelineTransform.transform(pipe);
-                        partialConfig.addPipeline(jsonPipeline, location);
+                        JsonElement jsonPipeline = pipelineTransform.transform(pipe, pipelineTag);
+                        if (jsonPipeline != null) {
+                            partialConfig.addPipeline(jsonPipeline, location);
+                        }
                     } catch (Exception ex) {
                         partialConfig.addError(new PluginError(
                                 String.format("Failed to parse pipeline %s; %s", pipe.getKey(), ex.getMessage()), location));

--- a/src/main/resource-templates/plugin.xml
+++ b/src/main/resource-templates/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<go-plugin id="yaml-tag.config.plugin" version="1">
+<go-plugin id="yaml.config.plugin" version="1">
     <about>
         <name>YAML Tag Configuration Plugin</name>
         <version>${version}</version>

--- a/src/main/resource-templates/plugin.xml
+++ b/src/main/resource-templates/plugin.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<go-plugin id="yaml.config.plugin" version="1">
+<go-plugin id="yaml-tag.config.plugin" version="1">
     <about>
-        <name>YAML Configuration Plugin</name>
+        <name>YAML Tag Configuration Plugin</name>
         <version>${version}</version>
         <target-go-version>${goCdVersion}</target-go-version>
         <description>
             GoCD pipelines and environments configuration in YAML
         </description>
         <vendor>
-            <name>Tomasz Setkowski</name>
-            <url>https://github.com/tomzo/gocd-yaml-config-plugin</url>
+            <name>Ashley Stovall</name>
+            <url>https://github.com/plainsane/gocd-yaml-config-plugin</url>
         </vendor>
     </about>
 </go-plugin>

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -3,3 +3,8 @@
     <input type="text" ng-model="file_pattern" ng-required="false" placeholder="**/*.gocd.yaml,**/*.gocd.yml" />
     <span class="form_error" ng-show="GOINPUTNAME[file_pattern].$error.server">{{ GOINPUTNAME[file_pattern].$error.server }}</span>
 </div>
+<div class="form_item_block">
+    <label>Go YAML pipeline tag:</label>
+    <input type="text" ng-model="pipeline_tag" ng-required="false" placeholder="master" />
+    <span class="form_error" ng-show="GOINPUTNAME[pipeline_tag].$error.server">{{ GOINPUTNAME[pipeline_tag].$error.server }}</span>
+</div>


### PR DESCRIPTION
first off, i do not expect you to accept this PR.  im really using it to begin a dialogue.

i work in an environment that has a very specific branching structure and a need for any and all things to travel this branching structure for the sake of security.

im using this plugin to leverage anchors to a high degree to keep multiple pipelines' behaviors in sync.

basically, i deploy code into multiple environments where each environment is its own aws account.  but the pipelines require different environmental config which is why i have a pipeline per environment (maybe gocd environments could help, but im missing it if they can) but using anchors for everything except environment variables to prevent snowflaking.  i hope this provides a decent description of my current state.  i can probably mock up an example to show you what im doing if needed.

the issue i have run into is that because all pipelines are defined in the same yaml file when i commit changes to my anchors, those changes go hot for every pipeline.  but i need to stagger the changes to the pipeline so they can progress through at the same rate as the "infrastructure as code" the pipeline is managing.  for example, i just finished a sprint that had to rework the flow of the pipeline to fail a specific resource before upgrade (didnt know that was coming).  this resource does not live in prod yet, so i do not want to risk "check for existence" errors from stopping production for a previous sprint that is about to go out to prod tomorrow.

this pull request adds a tag to the pipeline definition and a config option to pick up only pipelines with that tag.  the reason im doing this (and it may be stupid) is so that i can have a repo with my pipelines for all environments, BUT, when i commit to the dev branch, i have a plugin setting for the configrepo on the dev branch, only pick up pipelines tagged with dev.  so that way none of my qa/production pipelines are effected until i merge that branch upward, but i can fully test in lower environments first.

honestly, i hate the idea of putting a "tag" value in the plugin configuration, but i could not figure out (due to time pressure) how to get the branch name of the config repo from the cruise-control.xml file.

