### PR TITLE
Template front end

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'cd.go.plugin.config.yaml'
-version '0.7.0'
+version '0.8.0'
 
 apply plugin: 'java'
 

--- a/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
+++ b/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
@@ -2,15 +2,21 @@ package cd.go.plugin.config.yaml;
 
 public class PluginSettings {
     private String filePattern;
+    private String generatorConfigPattern;;
 
     public PluginSettings() {
     }
 
-    public PluginSettings(String filePattern) {
+    public PluginSettings(String filePattern, String generatorConfigPattern) {
         this.filePattern = filePattern;
+        this.generatorConfigPattern = generatorConfigPattern;
     }
 
     public String getFilePattern() {
         return filePattern;
+    }
+
+    public String getGeneratorConfigPattern() {
+        return generatorConfigPattern;
     }
 }

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -131,7 +131,7 @@ public class YamlConfigPlugin implements GoPlugin {
             if (generatorConfigFiles.length > 0) {
                 YamlGeneratorConfigParser parser = new YamlGeneratorConfigParser();
                 for (String file : generatorConfigFiles) {
-                    generators.addAll(parser.parseFile(file));
+                    generators.addAll(parser.parseFile(baseDir, file));
                 }
             }
 

--- a/src/main/java/cd/go/plugin/config/yaml/YamlFileParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlFileParser.java
@@ -5,6 +5,7 @@ import com.esotericsoftware.yamlbeans.YamlConfig;
 import com.esotericsoftware.yamlbeans.YamlReader;
 
 import java.io.*;
+import java.util.List;
 
 public class YamlFileParser {
     private RootTransform rootTransform;
@@ -17,7 +18,7 @@ public class YamlFileParser {
         this.rootTransform = rootTransform;
     }
 
-    public JsonConfigCollection parseFiles(File baseDir, String[] files) {
+    public JsonConfigCollection parseFiles(File baseDir, List<String> files) {
         JsonConfigCollection collection = new JsonConfigCollection();
         for (String file : files) {
             InputStream inputStream = null;

--- a/src/main/java/cd/go/plugin/config/yaml/YamlGenerator.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlGenerator.java
@@ -24,16 +24,17 @@ public class YamlGenerator {
         String[] inputFiles = scanner.getFilesMatchingPattern(baseDir, pattern);
         List<String> outputFiles = new ArrayList<>();
         for (String file : inputFiles) {
+            String outputFile = file + ".out";
+            String absPath = new File(baseDir, file).getAbsolutePath();
             ProcessBuilder builder = new ProcessBuilder();
-            String instance = script.replace("{{file}}", file);
+            String instance = script.replace("{{file}}", absPath);
             if (isWindows) {
                 builder.command("cmd.exe", "/c", instance);
             } else {
                 builder.command("sh", "-c", instance);
             }
-            String outputFile = file + ".out";
-            builder.redirectOutput(new File(outputFile));
-            builder.redirectError(new File(file + ".err"));
+            builder.redirectOutput(new File(baseDir, outputFile));
+            builder.redirectError(new File(absPath + ".err"));
             Process process = builder.start();
             int exitCode = process.waitFor();
             if (exitCode == 0)

--- a/src/main/java/cd/go/plugin/config/yaml/YamlGenerator.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlGenerator.java
@@ -1,0 +1,44 @@
+package cd.go.plugin.config.yaml;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class YamlGenerator {
+    private final String name;
+    private final String pattern;
+    private final String script;
+
+    private final static boolean isWindows =
+        System.getProperty("os.name").toLowerCase().startsWith("windows");
+
+    private final AntDirectoryScanner scanner = new AntDirectoryScanner();
+
+    public YamlGenerator(String name, String pattern, String script) {
+        this.name = name;
+        this.pattern = pattern;
+        this.script = script;
+    }
+
+    public List<String> generateFiles(File baseDir) throws Exception {
+        String[] inputFiles = scanner.getFilesMatchingPattern(baseDir, pattern);
+        List<String> outputFiles = new ArrayList<>();
+        for (String file : inputFiles) {
+            ProcessBuilder builder = new ProcessBuilder();
+            String instance = script.replace("{{file}}", file);
+            if (isWindows) {
+                builder.command("cmd.exe", "/c", instance);
+            } else {
+                builder.command("sh", "-c", instance);
+            }
+            String outputFile = file + ".out";
+            builder.redirectOutput(new File(outputFile));
+            builder.redirectError(new File(file + ".err"));
+            Process process = builder.start();
+            int exitCode = process.waitFor();
+            if (exitCode == 0)
+               outputFiles.add(outputFile);
+        }
+        return outputFiles;
+    }
+}

--- a/src/main/java/cd/go/plugin/config/yaml/YamlGeneratorConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlGeneratorConfigParser.java
@@ -1,5 +1,6 @@
 package cd.go.plugin.config.yaml;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -17,8 +18,8 @@ public class YamlGeneratorConfigParser {
         public String pattern;
         public String script;
     }
-    public List<YamlGenerator> parseFile(String file) {
-        try (FileInputStream inputStream = new FileInputStream(file)) {
+    public List<YamlGenerator> parseFile(File baseDir, String file) {
+        try (FileInputStream inputStream = new FileInputStream(new File(baseDir, file))) {
             YamlConfig config = new YamlConfig();
             config.setAllowDuplicates(false);
             YamlReader reader = new YamlReader(new InputStreamReader(inputStream), config);

--- a/src/main/java/cd/go/plugin/config/yaml/YamlGeneratorConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlGeneratorConfigParser.java
@@ -1,0 +1,43 @@
+package cd.go.plugin.config.yaml;
+
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.esotericsoftware.yamlbeans.YamlConfig;
+import com.esotericsoftware.yamlbeans.YamlReader;
+
+public class YamlGeneratorConfigParser {
+    private static class GeneratorConfigs {
+        public Map<String, GeneratorConfig> generators;
+    }
+    private static class GeneratorConfig {
+        public String pattern;
+        public String script;
+    }
+    public List<YamlGenerator> parseFile(String file) {
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            YamlConfig config = new YamlConfig();
+            config.setAllowDuplicates(false);
+            YamlReader reader = new YamlReader(new InputStreamReader(inputStream), config);
+            GeneratorConfigs configs = reader.read(GeneratorConfigs.class);
+            return createGenerators(configs);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+    private List<YamlGenerator> createGenerators(GeneratorConfigs configs) {
+        List<YamlGenerator> generators = new ArrayList<>();
+        for (Map.Entry<String, GeneratorConfig>
+                entry : configs.generators.entrySet()) {
+            generators.add(createGenerator(entry.getKey(), entry.getValue()));
+        }
+        return generators;
+    }
+    protected YamlGenerator createGenerator(String name, GeneratorConfig config) {
+        return new YamlGenerator(name, config.pattern, config.script);
+    }
+}

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -1,5 +1,7 @@
 <div class="form_item_block">
     <label>Go YAML files global pattern:</label>
     <input type="text" ng-model="file_pattern" ng-required="false" placeholder="**/*.gocd.yaml,**/*.gocd.yml" />
+    <label>Go YAML generator config files pattern:</label>
+    <input type="text" ng-model="generator_config_pattern" ng-required="false" placeholder="**/gocd-yaml-generator-config.yaml,**/gocd-yaml-generator-config.yml" />
     <span class="form_error" ng-show="GOINPUTNAME[file_pattern].$error.server">{{ GOINPUTNAME[file_pattern].$error.server }}</span>
 </div>

--- a/src/test/java/cd/go/plugin/config/yaml/PluginSettingsTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/PluginSettingsTest.java
@@ -9,9 +9,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class PluginSettingsTest {
     @Test
     public void shouldGetFilePattern() {
-        PluginSettings pluginSettings = new PluginSettings("file-pattern");
+        PluginSettings pluginSettings = new PluginSettings("file-pattern", "generator-config-pattern");
 
         assertThat(pluginSettings.getFilePattern(), is(equalTo("file-pattern")));
+        assertThat(pluginSettings.getGeneratorConfigPattern(), is(equalTo("generator-config-pattern")));
     }
 
 }


### PR DESCRIPTION
Potentially relevant to #2, though it's more of a idea to throw out there; I'm not sure it's exactly what was intended.

It's working well for us and supports the user's choice of templating engine.  Indeed, they could choose to use (or combine from different sources in one configrepo) different templating engines.

The only requirement is that you have a script or program to process files with a user-defined naming pattern.

**Example**

Example config: (`mustache.gocd-yaml-generator.yaml`)
```
generators:
  mustache-inline:
    pattern: '**/*.gocd.mi.yaml'
    script: |
      mustache-inline "{{file}}"
```
Example input: (`test.gocd.mi.yaml`)
```
---
branches:
    - name: master
    - name: demo
---
pipelines:
  {{#branches}}
  mcu-firmware.{{name}}:
    group: stuff
    label_template: "mcu-firmware-{{name}}.${COUNT}"
    materials:
      mcu-firmware:
        git: http://my-server/git/mcu-firmware
        branch: {{name}}
    stages:
      - build:
          clean_workspace: true
          artifacts:
           - build:
               source: out/mcu-firmware-*
               destination: mcu-firmware
          tasks:
           - script: |
              PATH="/usr/local/crosstool/gcc-arm-none-eabi-7-2018-q2-update/bin:$PATH"
              sh ./build.sh
  {{/branches}}
```
Note the file does not have to be combined (data and template) as the example above shows.  That was just convenient for demo.

Usage of "inclusion" within the chosen templating engine would allow the instantiating file to specify the data and a reference to the template to use.  With mustache something similar to
```
---
branches:
    - name: master
    - name: demo
---
pipelines:
  {{#branches}}
  {{> first-pipeline}}
  {{> second-pipeline}}
  {{/branches}}
```
Where `first-pipeline.mustache` and `second-pipeline.mustache` are local templates for particular pipelines.  They inherit the scope of the `branches` "loop" (i.e. can use `name` in this case).

I think this strategy gives a lot of flexibility.  I just wanted to put it out there to see if there was any interest in getting it (or something similar) merged into the main plugin.