### PR TITLE
Add export content metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'cd.go.plugin.config.yaml'
-version '0.8.3'
+version '0.8.4'
 
 apply plugin: 'java'
 

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -10,6 +10,7 @@ import com.thoughtworks.go.plugin.api.exceptions.UnhandledRequestTypeException;
 import com.thoughtworks.go.plugin.api.logging.Logger;
 import com.thoughtworks.go.plugin.api.request.GoApiRequest;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.apache.commons.io.IOUtils;
@@ -100,9 +101,14 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             ParsedRequest parsed = ParsedRequest.parse(request);
 
             Map<String, Object> pipeline = parsed.getParam("pipeline");
+            String name = (String) pipeline.get("name");
 
             Map<String, String> responseMap = Collections.singletonMap("pipeline", new RootTransform().inverseTransformPipeline(pipeline));
-            return success(gson.toJson(responseMap));
+            DefaultGoPluginApiResponse response = success(gson.toJson(responseMap));
+
+            response.addResponseHeader("Content-Type", "application/x-yaml; charset=utf-8");
+            response.addResponseHeader("X-Export-Filename", name + ".gocd.yaml");
+            return response;
         });
     }
 


### PR DESCRIPTION
Adds response headers to the API to give hints about the response payload (i.e., exported content):

  - `Content-Type`: self-explanatory
  - `X-Export-Filename`: non-standard header to suggest a filename for the content. This will be used to construct `Content-Disposition` in GoCD's new pipeline export links.
    - _Why not use `Content-Disposition` directly?_ Firstly, this is a matter of opinion, and I'm open to alternatives. So here's the explanation: In GoCD, we really only want to know how to name the file we construct for pipeline export, so I didn't want to open the door for supporting other aspects of `Content-Disposition` from the plugin side (i.e., `attachment` vs `inline` vs `form-data` -- we just want the `; filename=XXX` segment). On the GoCD side, we will use this header to enforce a `Content-Disposition: attachment; filename=<header value goes here>` on GoCD's public REST APIs.

Thoughts @tomzo @arvindsv?