### PR TITLE
Fix absolute paths and file descriptor refs in CLI

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/cli/YamlPluginCli.java
+++ b/src/main/java/cd/go/plugin/config/yaml/cli/YamlPluginCli.java
@@ -64,7 +64,7 @@ public class YamlPluginCli {
     private static InputStream getFileAsStream(String file) {
         InputStream s = null;
         try {
-            s = "-".equals(file) ? System.in : new FileInputStream(new File(".", file));
+            s = "-".equals(file) ? System.in : new FileInputStream(new File(file));
         } catch (FileNotFoundException e) {
             die(1, e.getMessage());
         }


### PR DESCRIPTION
No need to prepend "." to files
  - redundant for rel paths
  - breaks abs paths (and ad-hoc file descriptor args, e.g. /dev/fd/XX)