### PR TITLE
Add support for parsing the content of a file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 group 'cd.go.plugin.config.yaml'
-version '0.8.2'
+version '0.8.3'
 
 apply plugin: 'java'
 
 project.ext.pluginDesc = [
         version    : project.version,
-        goCdVersion: '18.11.0'
+        goCdVersion: '18.12.0'
 ]
 
 sourceCompatibility = 1.8

--- a/src/main/java/cd/go/plugin/config/yaml/Capabilities.java
+++ b/src/main/java/cd/go/plugin/config/yaml/Capabilities.java
@@ -2,9 +2,11 @@ package cd.go.plugin.config.yaml;
 
 public class Capabilities {
     private boolean supportsPipelineExport;
+    private boolean supportsParseContent;
 
     public Capabilities() {
         this.supportsPipelineExport = true;
+        this.supportsParseContent = true;
     }
 
     public boolean isSupportsPipelineExport() {
@@ -13,5 +15,13 @@ public class Capabilities {
 
     public void setSupportsPipelineExport(boolean supportsPipelineExport) {
         this.supportsPipelineExport = supportsPipelineExport;
+    }
+
+    public boolean isSupportsParseContent() {
+        return supportsParseContent;
+    }
+
+    public void setSupportsParseContent(boolean supportsParseContent) {
+        this.supportsParseContent = supportsParseContent;
     }
 }

--- a/src/main/java/cd/go/plugin/config/yaml/ConfigRepoMessages.java
+++ b/src/main/java/cd/go/plugin/config/yaml/ConfigRepoMessages.java
@@ -7,5 +7,6 @@ public interface ConfigRepoMessages {
     String REQ_PLUGIN_SETTINGS_GET_VIEW = "go.plugin-settings.get-view";
     String REQ_PLUGIN_SETTINGS_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";
     String REQ_PARSE_DIRECTORY = "parse-directory";
+    String REQ_PARSE_CONTENT = "parse-content";
     String REQ_PIPELINE_EXPORT = "pipeline-export";
 }

--- a/src/main/java/cd/go/plugin/config/yaml/JsonConfigCollection.java
+++ b/src/main/java/cd/go/plugin/config/yaml/JsonConfigCollection.java
@@ -9,7 +9,7 @@ public class JsonConfigCollection {
     private static final int DEFAULT_VERSION = 1;
     private final Gson gson;
 
-    private Set<Integer> uniqueVersions = new HashSet<Integer>();
+    private Set<Integer> uniqueVersions = new HashSet<>();
     private JsonObject mainObject = new JsonObject();
     private JsonArray environments = new JsonArray();
     private JsonArray pipelines = new JsonArray();

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -82,9 +82,13 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             ParsedRequest parsed = ParsedRequest.parse(request);
 
             YamlConfigParser parser = new YamlConfigParser();
-            String content = parsed.getStringParam("content");
+            List<Map<String, String>> contents = parsed.getParam("contents");
             JsonConfigCollection result = new JsonConfigCollection();
-            parser.parseStream(result, new ByteArrayInputStream(content.getBytes()), "content");
+            contents.forEach(file -> {
+                String filename = file.keySet().iterator().next();
+                String content = file.get(filename);
+                parser.parseStream(result, new ByteArrayInputStream(content.getBytes()), filename);
+            });
             result.updateTargetVersionFromFiles();
 
             return success(gson.toJson(result.getJsonObject()));

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -14,6 +14,7 @@ import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.apache.commons.io.IOUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
@@ -63,6 +64,8 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
                 }
             case REQ_PLUGIN_SETTINGS_VALIDATE_CONFIGURATION:
                 return handleValidatePluginSettingsConfiguration();
+            case REQ_PARSE_CONTENT:
+                return handleParseContentRequest(request);
             case REQ_PARSE_DIRECTORY:
                 return handleParseDirectoryRequest(request);
             case REQ_PIPELINE_EXPORT:
@@ -72,6 +75,20 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             default:
                 throw new UnhandledRequestTypeException(requestName);
         }
+    }
+
+    private GoPluginApiResponse handleParseContentRequest(GoPluginApiRequest request) {
+        return handlingErrors(() -> {
+            ParsedRequest parsed = ParsedRequest.parse(request);
+
+            YamlConfigParser parser = new YamlConfigParser();
+            String content = parsed.getStringParam("content");
+            JsonConfigCollection result = new JsonConfigCollection();
+            parser.parseStream(result, new ByteArrayInputStream(content.getBytes()), "content");
+            result.updateTargetVersionFromFiles();
+
+            return success(gson.toJson(result.getJsonObject()));
+        });
     }
 
     private GoPluginApiResponse handlePipelineExportRequest(GoPluginApiRequest request) {

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -54,7 +54,11 @@ public class YamlConfigPluginIntegrationTest {
 
         StringWriter w = new StringWriter();
         IOUtils.copy(getResourceAsStream("examples/simple.gocd.yaml"), w);
-        request.setRequestBody(gson.toJson(Collections.singletonMap("content", w.toString())));
+        request.setRequestBody(gson.toJson(
+                Collections.singletonMap("contents",
+                        Collections.singletonList(Collections.singletonMap("simple.gocd.yaml", w.toString()))
+                )
+        ));
 
         GoPluginApiResponse response = plugin.handle(request);
         assertEquals(SUCCESS_RESPONSE_CODE, response.responseCode());
@@ -64,7 +68,6 @@ public class YamlConfigPluginIntegrationTest {
         JsonArray pipelines = responseJsonObject.get("pipelines").getAsJsonArray();
         assertThat(pipelines.size(), is(1));
         JsonObject expected = (JsonObject) readJsonObject("examples.out/simple.gocd.json");
-        expected.getAsJsonArray("pipelines").get(0).getAsJsonObject().addProperty("location", "content");
         assertThat(responseJsonObject, is(new JsonObjectMatcher(expected)));
     }
 


### PR DESCRIPTION
As part of the GoCD CLI we want to support a preflight function to validate potential changes to a config. The preflight function will be a public API so we want to be able to parse arbitrary strings vs reading contents from a file system. This is what parse content does. 
 
Corresponding PR https://github.com/gocd/gocd/pull/5579 
Additional context https://github.com/gocd/gocd/issues/5489