### PR TITLE
Fix plugin settings request and implement handler for plugin config change notification

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/ConfigRepoMessages.java
+++ b/src/main/java/cd/go/plugin/config/yaml/ConfigRepoMessages.java
@@ -3,6 +3,7 @@ package cd.go.plugin.config.yaml;
 public interface ConfigRepoMessages {
     String REQ_GET_PLUGIN_SETTINGS = "go.processor.plugin-settings.get";
     String REQ_GET_CAPABILITIES = "get-capabilities";
+    String REQ_PLUGIN_SETTINGS_CHANGED = "go.plugin-settings.plugin-settings-changed";
     String REQ_PLUGIN_SETTINGS_GET_CONFIGURATION = "go.plugin-settings.get-configuration";
     String REQ_PLUGIN_SETTINGS_GET_VIEW = "go.plugin-settings.get-view";
     String REQ_PLUGIN_SETTINGS_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";

--- a/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
+++ b/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
@@ -1,16 +1,26 @@
 package cd.go.plugin.config.yaml;
 
-public class PluginSettings {
+import java.util.Map;
+
+class PluginSettings {
+    static final String PLUGIN_SETTINGS_FILE_PATTERN = "file_pattern";
+    static final String DEFAULT_FILE_PATTERN = "**/*.gocd.yaml,**/*.gocd.yml";
+
     private String filePattern;
 
-    public PluginSettings() {
+    PluginSettings() {
     }
 
-    public PluginSettings(String filePattern) {
+    PluginSettings(String filePattern) {
         this.filePattern = filePattern;
     }
 
-    public String getFilePattern() {
+    static PluginSettings fromJson(String json) {
+        Map<String, String> raw = JSONUtils.fromJSON(json);
+        return new PluginSettings(raw.get(PLUGIN_SETTINGS_FILE_PATTERN));
+    }
+
+    String getFilePattern() {
         return filePattern;
     }
 }

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -148,7 +148,7 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
         });
     }
 
-    private boolean isBlank(String pattern) {
+    private static boolean isBlank(String pattern) {
         return pattern == null || pattern.isEmpty();
     }
 

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Collections;
 
+import static cd.go.plugin.config.yaml.ConfigRepoMessages.REQ_PLUGIN_SETTINGS_CHANGED;
+import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_FILE_PATTERN;
 import static cd.go.plugin.config.yaml.TestUtils.getResourceAsStream;
 import static cd.go.plugin.config.yaml.TestUtils.readJsonObject;
 import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE;
@@ -244,12 +246,17 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     @Test
-    public void shouldTalkToGoApplicationAccessorToGetPluginSettings() throws UnhandledRequestTypeException {
-        GoPluginApiResponse response = parseAndGetResponseForDir(tempDir.getRoot());
+    public void shouldConsumePluginSettingsOnConfigChangeRequest() throws UnhandledRequestTypeException {
+        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
+        request.setRequestBody("{\"file_pattern\": \"*.foo.gocd.yaml\"}");
 
-        verify(goAccessor, times(1)).submit(any(GoApiRequest.class));
+        assertEquals(DEFAULT_FILE_PATTERN, plugin.getFilePattern());
+        GoPluginApiResponse response = plugin.handle(request);
+
+        assertEquals("*.foo.gocd.yaml", plugin.getFilePattern());
         assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
     }
+
 
     @Test
     public void shouldRespondSuccessToParseDirectoryRequestWhenPluginHasConfiguration() throws UnhandledRequestTypeException {


### PR DESCRIPTION
Since the initial pipeline export work, we have been sending the wrong api version when
fetching plugin settings. This was causing some issues during parse directory. The general
move to extension v2 also caused some issues during plugin load. This PR resolves this.

@tomzo this needs to be merged, or else we'll be shipping broken plugins :/