### PR TITLE
We should always return CLI results as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Follow the steps on [https://github.com/gocd-contrib/gocd-cli](https://github.co
 Then:
 
 ```bash
-./gocd configrepo check -i yaml.config.plugin /path/to/your-pipeline.gocd.yaml
+./gocd configrepo syntax -i yaml.config.plugin /path/to/your-pipeline.gocd.yaml
 ```
 
 ## Usage with IDE and docker

--- a/src/main/java/cd/go/plugin/config/yaml/cli/YamlPluginCli.java
+++ b/src/main/java/cd/go/plugin/config/yaml/cli/YamlPluginCli.java
@@ -51,9 +51,10 @@ public class YamlPluginCli {
             JsonObject result = collection.getJsonObject();
             result.remove("environments");
             result.remove("pipelines");
+            result.addProperty("valid", false);
             die(1, result.toString());
         } else {
-            die(0, "OK");
+            die(0, "{\"valid\":true}");
         }
     }
 


### PR DESCRIPTION
@tomzo One last (tiny) PR before cutting a stable release.

This is for the CLI output from the plugin jar; wanted to be consistent and always output JSON. The GoCD CLI should handle the presentation to the user.