### PR TITLE
Changed JSON keys returned by `get-capabilities` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Changed JSON keys returned by `get-capabilities` call
+
 # 0.8.5 (15 Jan 2019)
 
  * return json from CLI command

--- a/src/main/java/cd/go/plugin/config/yaml/Capabilities.java
+++ b/src/main/java/cd/go/plugin/config/yaml/Capabilities.java
@@ -1,7 +1,14 @@
 package cd.go.plugin.config.yaml;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
 public class Capabilities {
+    @Expose
+    @SerializedName("supports_pipeline_export")
     private boolean supportsPipelineExport;
+    @Expose
+    @SerializedName("supports_parse_content")
     private boolean supportsParseContent;
 
     public Capabilities() {


### PR DESCRIPTION
The returned JSON uses snake-cased keys, instead of the camel case keys
used earlier.