### PR TITLE
Added Jinja templating preprocessing engine as well as unit test fixes when running on Windows.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ group 'cd.go.plugin.config.yaml'
 version '0.8.6'
 
 apply plugin: 'java'
+apply plugin: 'idea'
 
 project.ext.pluginDesc = [
         version    : project.version,
@@ -22,6 +23,7 @@ dependencies {
     compile group: 'com.beust', name: 'jcommander', version: '1.72'
     compile group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version: '1.13'
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.23'
+    compile group: 'com.hubspot.jinjava', name: 'jinjava', version: '2.4.14'
 
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginDesc.goCdVersion
     testCompile group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginDesc.goCdVersion

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Jan 28 14:59:25 MST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
@@ -1,10 +1,18 @@
 package cd.go.plugin.config.yaml;
 
 import cd.go.plugin.config.yaml.transforms.RootTransform;
+import com.beust.jcommander.internal.Maps;
 import com.esotericsoftware.yamlbeans.YamlConfig;
 import com.esotericsoftware.yamlbeans.YamlReader;
+import com.hubspot.jinjava.interpret.RenderResult;
+import org.apache.commons.io.Charsets;
+import com.google.common.io.Resources;
+import com.hubspot.jinjava.Jinjava;
 
 import java.io.*;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Scanner;
 
 public class YamlConfigParser {
     private RootTransform rootTransform;
@@ -32,22 +40,39 @@ public class YamlConfigParser {
     }
 
     public void parseStream(JsonConfigCollection result, InputStream input, String location) {
-        try (InputStreamReader contentReader = new InputStreamReader(input)) {
-            if (input.available() < 1) {
-                result.addError("File is empty", location);
-                return;
-            }
+        RenderResult renderedResult;
 
-            YamlConfig config = new YamlConfig();
-            config.setAllowDuplicates(false);
-            YamlReader reader = new YamlReader(contentReader, config);
-            Object rootObject = reader.read();
-            JsonConfigCollection filePart = rootTransform.transform(rootObject, location);
-            result.append(filePart);
-        } catch (YamlReader.YamlReaderException e) {
-            result.addError(e.getMessage(), location);
-        } catch (IOException e) {
-            result.addError(e.getMessage() + " : " + e.getCause().getMessage() + " : ", location);
+        //Jinjava requires a String as input so read the file (inputStream) into memory as a string
+        Scanner s = new Scanner(input).useDelimiter("\\A");
+        String template = s.hasNext() ? s.next() : "";
+        if (template.isEmpty()) {
+            result.addError("File is empty", location);
+            return;
+        }
+        //Pre-Process the file through the jinja template engine
+        Jinjava jinjava = new Jinjava();
+        renderedResult = jinjava.renderForResult(template, Maps.newHashMap());
+
+        //If no errors, the run the result through the YamlReader()
+        if (renderedResult.getErrors().isEmpty()) {
+            InputStream renderedStream = new ByteArrayInputStream(renderedResult.getOutput().getBytes(Charset.forName("UTF-8")));
+
+            try (InputStreamReader renderedReader = new InputStreamReader(renderedStream)) {
+                YamlConfig config = new YamlConfig();
+                config.setAllowDuplicates(false);
+                YamlReader reader = new YamlReader(renderedReader, config);
+                Object rootObject = reader.read();
+                JsonConfigCollection filePart = rootTransform.transform(rootObject, location);
+                result.append(filePart);
+            } catch (YamlReader.YamlReaderException e) {
+                result.addError(e.getMessage(), location);
+            } catch (IOException e) {
+                result.addError(e.getMessage() + " : " + e.getCause().getMessage() + " : ", location);
+            }
+        } else {
+            renderedResult.getErrors().forEach(e -> {
+                result.addError(e.getMessage(), location);
+            });
         }
     }
 }

--- a/src/test/java/cd/go/plugin/config/yaml/AntDirectoryScannerTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/AntDirectoryScannerTest.java
@@ -5,6 +5,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,22 +41,34 @@ public class AntDirectoryScannerTest {
 
     @Test
     public void shouldMatchPatternInDirectory() throws Exception {
+        List<String> expectedItems = Arrays.asList(
+                "1/a/abc.xml",
+                "2/d/def.xml",
+                "3/ghi.xml",
+                "pqr.xml"
+        );
+
         tempDir.newFolder("1", "a");
         tempDir.newFolder("2", "d");
         tempDir.newFolder("3");
         tempDir.newFolder("4");
 
-        tempDir.newFile("1/a/abc.xml");
-        tempDir.newFile("2/d/def.xml");
-        tempDir.newFile("3/ghi.xml");
+        expectedItems.forEach(item -> {
+            try {
+                tempDir.newFile(item);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
         tempDir.newFile("4/jkl.txt");
         tempDir.newFile("mno.txt");
-        tempDir.newFile("pqr.xml");
 
-        String[] xmlFilesOnly = scanner.getFilesMatchingPattern(tempDir.getRoot(), "**/*.xml");
+        List<String> xmlFilesOnly = Arrays.asList(scanner.getFilesMatchingPattern(tempDir.getRoot(), "**/*.xml"));
 
-        assertThat(xmlFilesOnly.length, is(4));
-        assertThat(asList(xmlFilesOnly), hasItems("1/a/abc.xml", "2/d/def.xml", "3/ghi.xml", "pqr.xml"));
+        assertThat(xmlFilesOnly.size(), is(4));
+        assertThat(
+                asList(xmlFilesOnly.stream().map(s -> TestUtils.normalizePath(s)).collect(Collectors.toList()))
+                , hasItems(expectedItems.stream().map(s -> TestUtils.normalizePath(s)).collect(Collectors.toList())));
     }
 
     @Test
@@ -66,22 +84,34 @@ public class AntDirectoryScannerTest {
 
     @Test
     public void shouldAcceptMultiplePatternsSeparatedByComma() throws Exception {
+        List<String> expectedItems = Arrays.asList(
+                "1/a/abc.xml",
+                "2/d/def.gif",
+                "3/ghi.xml",
+                "mno.jpg",
+                "stu.xml"
+        );
+
         tempDir.newFolder("1", "a");
         tempDir.newFolder("2", "d");
         tempDir.newFolder("3");
         tempDir.newFolder("4");
 
-        tempDir.newFile("1/a/abc.xml");
-        tempDir.newFile("2/d/def.gif");
-        tempDir.newFile("3/ghi.xml");
+        expectedItems.forEach(item -> {
+            try {
+                tempDir.newFile(item);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
         tempDir.newFile("4/jkl.txt");
-        tempDir.newFile("mno.jpg");
-        tempDir.newFile("4/pqr.jpg");
-        tempDir.newFile("stu.xml");
 
-        String[] xmlFilesOnly = scanner.getFilesMatchingPattern(tempDir.getRoot(), "**/*.xml, **/*.gif, *.jpg");
+        List<String> xmlFilesOnly = Arrays.asList(scanner.getFilesMatchingPattern(tempDir.getRoot(), "**/*.xml, **/*.gif, *.jpg"));
 
-        assertThat(xmlFilesOnly.length, is(5));
-        assertThat(asList(xmlFilesOnly), hasItems("1/a/abc.xml", "2/d/def.gif", "3/ghi.xml", "mno.jpg", "stu.xml"));
+        assertThat(xmlFilesOnly.size(), is(5));
+//        assertThat(asList(xmlFilesOnly), hasItems("1/a/abc.xml", "2/d/def.gif", "3/ghi.xml", "mno.jpg", "stu.xml"));
+        assertThat(
+                asList(xmlFilesOnly.stream().map(s -> TestUtils.normalizePath(s)).collect(Collectors.toList()))
+                , hasItems(expectedItems.stream().map(s -> TestUtils.normalizePath(s)).collect(Collectors.toList())));
     }
 }

--- a/src/test/java/cd/go/plugin/config/yaml/TestUtils.java
+++ b/src/test/java/cd/go/plugin/config/yaml/TestUtils.java
@@ -9,10 +9,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.io.IOUtils;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.*;
 import java.util.List;
 import java.util.Map;
 
@@ -72,4 +69,18 @@ public class TestUtils {
     private static ClassLoader getContextClassLoader() {
         return Thread.currentThread().getContextClassLoader();
     }
+
+    public static String normalizePath(File directory) {
+            return normalizePath(directory.getAbsolutePath());
+    }
+
+    public static String normalizePath(String directory) {
+        String directoryString = directory;
+
+        if (System.getProperty("os.name").contains("Windows")) {
+            directoryString = directoryString.replaceAll("\\\\", "/");
+        }
+        return directoryString;
+    }
+
 }

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -158,7 +158,7 @@ public class YamlConfigPluginIntegrationTest {
         JsonObject responseJsonObject = getJsonObjectFromResponse(response);
         assertNoError(responseJsonObject);
         JsonArray pipelines = responseJsonObject.get("pipelines").getAsJsonArray();
-        assertThat(pipelines.size(), is(3);
+        assertThat(pipelines.size(), is(3));
         JsonObject expected = (JsonObject) readJsonObject("examples.out/rich-jinja.gocd.json");
         assertThat(responseJsonObject, is(new JsonObjectMatcher(expected)));
     }
@@ -212,8 +212,9 @@ public class YamlConfigPluginIntegrationTest {
     public void shouldParseDirectoryWithCustomPatternWhenInConfigurations() throws UnhandledRequestTypeException, IOException {
         File simpleCaseDir = setupCase("simple", "go.yml");
         DefaultGoPluginApiRequest parseDirectoryRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "parse-directory");
+        String normalizedPath = TestUtils.normalizePath(simpleCaseDir);
         String requestBody = "{\n" +
-                "    \"directory\":\"" + simpleCaseDir + "\",\n" +
+                "    \"directory\":\"" + normalizedPath + "\",\n" +
                 "    \"configurations\":[" +
                 "{" +
                 "\"key\" : \"file_pattern\"," +
@@ -382,7 +383,7 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     private GoPluginApiResponse parseAndGetResponseForDir(File directory) throws UnhandledRequestTypeException {
-        String normalizedDir = normalizePath(directory);
+        String normalizedDir = TestUtils.normalizePath(directory);
         DefaultGoPluginApiRequest parseDirectoryRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "parse-directory");
         String requestBody = "{\n" +
                 "    \"directory\":\"" + normalizedDir + "\",\n" +
@@ -391,15 +392,6 @@ public class YamlConfigPluginIntegrationTest {
         parseDirectoryRequest.setRequestBody(requestBody);
 
         return plugin.handle(parseDirectoryRequest);
-    }
-
-    private String normalizePath(File directory) {
-        String directoryString = directory.getAbsolutePath();
-
-        if (System.getProperty("os.name").contains("Windows")) {
-            directoryString = directoryString.replaceAll("\\\\", "/");
-        }
-        return directoryString;
     }
 
     private void assertNoError(JsonObject responseJsonObject) {

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -151,6 +151,19 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     @Test
+    public void shouldRespondSuccessToParseDirectoryRequestWhenRichJinjaCaseFile() throws UnhandledRequestTypeException, IOException {
+        GoPluginApiResponse response = parseAndGetResponseForDir(setupCase("rich-jinja"));
+
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        JsonObject responseJsonObject = getJsonObjectFromResponse(response);
+        assertNoError(responseJsonObject);
+        JsonArray pipelines = responseJsonObject.get("pipelines").getAsJsonArray();
+        assertThat(pipelines.size(), is(3);
+        JsonObject expected = (JsonObject) readJsonObject("examples.out/rich-jinja.gocd.json");
+        assertThat(responseJsonObject, is(new JsonObjectMatcher(expected)));
+    }
+
+    @Test
     public void shouldRespondSuccessWithErrorMessagesToParseDirectoryRequestWhenSimpleInvalidCaseFile() throws UnhandledRequestTypeException, IOException {
         GoPluginApiResponse response = parseAndGetResponseForDir(setupCase("simple-invalid"));
 
@@ -369,14 +382,24 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     private GoPluginApiResponse parseAndGetResponseForDir(File directory) throws UnhandledRequestTypeException {
+        String normalizedDir = normalizePath(directory);
         DefaultGoPluginApiRequest parseDirectoryRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "parse-directory");
         String requestBody = "{\n" +
-                "    \"directory\":\"" + directory + "\",\n" +
+                "    \"directory\":\"" + normalizedDir + "\",\n" +
                 "    \"configurations\":[]\n" +
                 "}";
         parseDirectoryRequest.setRequestBody(requestBody);
 
         return plugin.handle(parseDirectoryRequest);
+    }
+
+    private String normalizePath(File directory) {
+        String directoryString = directory.getAbsolutePath();
+
+        if (System.getProperty("os.name").contains("Windows")) {
+            directoryString = directoryString.replaceAll("\\\\", "/");
+        }
+        return directoryString;
     }
 
     private void assertNoError(JsonObject responseJsonObject) {

--- a/src/test/resources/examples.out/rich-jinja.gocd.json
+++ b/src/test/resources/examples.out/rich-jinja.gocd.json
@@ -1,0 +1,352 @@
+{
+  "target_version": 1,
+  "environments": [],
+  "pipelines": [
+    {
+      "name": "pipe1",
+      "group": "rich-jinja",
+      "label_template": "${mygit[:8]}",
+      "enable_pipeline_locking": true,
+      "tracking_tool": {
+        "link": "http://your-trackingtool/yourproject/${ID}",
+        "regex": "evo-(\\d+)"
+      },
+      "timer": {
+        "spec": "0 0 22 ? * MON-FRI",
+        "only_on_changes": true
+      },
+      "materials": [
+        {
+          "name": "mygit",
+          "type": "git",
+          "url": "http://my.example.org/mygit.git",
+          "branch": "ci"
+        },
+        {
+          "name": "upstream",
+          "type": "dependency",
+          "pipeline": "pipe1",
+          "stage": "test"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "clean_working_directory": true,
+          "approval": {
+            "type": "manual",
+            "roles": [
+              "manager"
+            ]
+          },
+          "jobs": [
+            {
+              "name": "csharp",
+              "run_instance_count": 3,
+              "environment_variables": [
+                {
+                  "name": "MONO_PATH",
+                  "value": "/usr/bin/local/mono"
+                },
+                {
+                  "name": "PASSWORD",
+                  "encrypted_value": "s&Du#@$xsSa"
+                }
+              ],
+              "tabs": [
+                {
+                  "name": "report",
+                  "path": "test-reports/index.html"
+                }
+              ],
+              "resources": [
+                "net45"
+              ],
+              "artifacts": [
+                {
+                  "type": "build",
+                  "source": "bin/",
+                  "destination": "build"
+                },
+                {
+                  "type": "test",
+                  "source": "tests/",
+                  "destination": "test-reports/"
+                }
+              ],
+              "properties": [
+                {
+                  "name": "perf",
+                  "source": "test.xml",
+                  "xpath": "substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')"
+                }
+              ],
+              "tasks": [
+                {
+                  "type": "fetch",
+                  "pipeline": "pipe1",
+                  "stage": "build",
+                  "job": "test",
+                  "source": "test-bin/",
+                  "destination": "bin/"
+                },
+                {
+                  "type": "exec",
+                  "arguments": [
+                    "VERBOSE=true"
+                  ],
+                  "command": "make"
+                },
+                {
+                  "type": "plugin",
+                  "configuration": [
+                    {
+                      "key": "script",
+                      "value": "./build.sh ci"
+                    }
+                  ],
+                  "plugin_configuration": {
+                    "id": "script-executor",
+                    "version": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "location": "rich-jinja.gocd.yaml"
+    },
+    {
+      "name": "pipe2",
+      "group": "rich-jinja",
+      "label_template": "${mygit[:8]}",
+      "enable_pipeline_locking": true,
+      "tracking_tool": {
+        "link": "http://your-trackingtool/yourproject/${ID}",
+        "regex": "evo-(\\d+)"
+      },
+      "timer": {
+        "spec": "0 0 22 ? * MON-FRI",
+        "only_on_changes": true
+      },
+      "materials": [
+        {
+          "name": "mygit",
+          "type": "git",
+          "url": "http://my.example.org/mygit.git",
+          "branch": "ci"
+        },
+        {
+          "name": "upstream",
+          "type": "dependency",
+          "pipeline": "pipe2",
+          "stage": "test"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "clean_working_directory": true,
+          "approval": {
+            "type": "manual",
+            "roles": [
+              "manager"
+            ]
+          },
+          "jobs": [
+            {
+              "name": "csharp",
+              "run_instance_count": 3,
+              "environment_variables": [
+                {
+                  "name": "MONO_PATH",
+                  "value": "/usr/bin/local/mono"
+                },
+                {
+                  "name": "PASSWORD",
+                  "encrypted_value": "s&Du#@$xsSa"
+                }
+              ],
+              "tabs": [
+                {
+                  "name": "report",
+                  "path": "test-reports/index.html"
+                }
+              ],
+              "resources": [
+                "net45"
+              ],
+              "artifacts": [
+                {
+                  "type": "build",
+                  "source": "bin/",
+                  "destination": "build"
+                },
+                {
+                  "type": "test",
+                  "source": "tests/",
+                  "destination": "test-reports/"
+                }
+              ],
+              "properties": [
+                {
+                  "name": "perf",
+                  "source": "test.xml",
+                  "xpath": "substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')"
+                }
+              ],
+              "tasks": [
+                {
+                  "type": "fetch",
+                  "pipeline": "pipe2",
+                  "stage": "build",
+                  "job": "test",
+                  "source": "test-bin/",
+                  "destination": "bin/"
+                },
+                {
+                  "type": "exec",
+                  "arguments": [
+                    "VERBOSE=true"
+                  ],
+                  "command": "make"
+                },
+                {
+                  "type": "plugin",
+                  "configuration": [
+                    {
+                      "key": "script",
+                      "value": "./build.sh ci"
+                    }
+                  ],
+                  "plugin_configuration": {
+                    "id": "script-executor",
+                    "version": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "location": "rich-jinja.gocd.yaml"
+    },
+    {
+      "name": "pipe3",
+      "group": "rich-jinja",
+      "label_template": "${mygit[:8]}",
+      "enable_pipeline_locking": true,
+      "tracking_tool": {
+        "link": "http://your-trackingtool/yourproject/${ID}",
+        "regex": "evo-(\\d+)"
+      },
+      "timer": {
+        "spec": "0 0 22 ? * MON-FRI",
+        "only_on_changes": true
+      },
+      "materials": [
+        {
+          "name": "mygit",
+          "type": "git",
+          "url": "http://my.example.org/mygit.git",
+          "branch": "ci"
+        },
+        {
+          "name": "upstream",
+          "type": "dependency",
+          "pipeline": "pipe3",
+          "stage": "test"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "clean_working_directory": true,
+          "approval": {
+            "type": "manual",
+            "roles": [
+              "manager"
+            ]
+          },
+          "jobs": [
+            {
+              "name": "csharp",
+              "run_instance_count": 3,
+              "environment_variables": [
+                {
+                  "name": "MONO_PATH",
+                  "value": "/usr/bin/local/mono"
+                },
+                {
+                  "name": "PASSWORD",
+                  "encrypted_value": "s&Du#@$xsSa"
+                }
+              ],
+              "tabs": [
+                {
+                  "name": "report",
+                  "path": "test-reports/index.html"
+                }
+              ],
+              "resources": [
+                "net45"
+              ],
+              "artifacts": [
+                {
+                  "type": "build",
+                  "source": "bin/",
+                  "destination": "build"
+                },
+                {
+                  "type": "test",
+                  "source": "tests/",
+                  "destination": "test-reports/"
+                }
+              ],
+              "properties": [
+                {
+                  "name": "perf",
+                  "source": "test.xml",
+                  "xpath": "substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')"
+                }
+              ],
+              "tasks": [
+                {
+                  "type": "fetch",
+                  "pipeline": "pipe3",
+                  "stage": "build",
+                  "job": "test",
+                  "source": "test-bin/",
+                  "destination": "bin/"
+                },
+                {
+                  "type": "exec",
+                  "arguments": [
+                    "VERBOSE=true"
+                  ],
+                  "command": "make"
+                },
+                {
+                  "type": "plugin",
+                  "configuration": [
+                    {
+                      "key": "script",
+                      "value": "./build.sh ci"
+                    }
+                  ],
+                  "plugin_configuration": {
+                    "id": "script-executor",
+                    "version": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "location": "rich-jinja.gocd.yaml"
+    }
+  ],
+  "errors": []
+}

--- a/src/test/resources/examples/rich-jinja.gocd.yaml
+++ b/src/test/resources/examples/rich-jinja.gocd.yaml
@@ -1,0 +1,66 @@
+# rich-jinja.gocd.yaml
+pipelines: # tells plugin that here are pipelines by name
+{% for pipelineName in ['pipe1','pipe2','pipe3'] %}
+  {{ pipelineName }}:
+    group: rich-jinja
+    label_template: "${mygit[:8]}"
+    locking: on
+    tracking_tool:
+      link: "http://your-trackingtool/yourproject/${ID}"
+      regex: "evo-(\\d+)"
+    timer:
+      spec: "0 0 22 ? * MON-FRI"
+      only_on_changes: true
+    materials:
+      mygit: # this is the name of material
+        # says about type of material and url at once
+        git: http://my.example.org/mygit.git
+        branch: ci
+      upstream:
+        # type is optional here, material type is implied based on pipeline and stage fields
+        type: dependency
+        pipeline: {{ pipelineName }}
+        stage: test
+    stages:
+      - build: # name of stage
+          clean_workspace: true
+          approval:
+            type: manual
+            roles:
+              - manager
+          jobs:
+            csharp: # name of the job
+              run_instances: 3
+              resources:
+               - net45
+              artifacts:
+               - build:
+                   source: bin/
+                   destination: build
+               - test:
+                   source: tests/
+                   destination: test-reports/
+              tabs:
+                report: test-reports/index.html
+              environment_variables:
+                MONO_PATH: /usr/bin/local/mono
+              secure_variables:
+                PASSWORD: "s&Du#@$xsSa"
+              properties:
+                perf:
+                  source: test.xml
+                  xpath: "substring-before(//report/data/all/coverage[starts-with(@type,\u0027class\u0027)]/@value, \u0027%\u0027)"
+              tasks:
+               - fetch:
+                   pipeline: {{ pipelineName }}
+                   stage: build
+                   job: test
+                   source: test-bin/
+                   destination: bin/
+               - exec: # indicates type of task
+                   command: make
+                   arguments:
+                    - "VERBOSE=true"
+              # shorthand for script-executor plugin
+               - script: ./build.sh ci
+{% endfor %}


### PR DESCRIPTION
I've added the Jinjava Jinja pre-processing engine to the plugin to allow for embedded Jinja templates.  

I'm not yet completely aware of what limitations might exist in Jinjava compared to official Jinja/Jinja2 implementations.

The unit test is minimal (creates 3 pipelines in a loop) but I can add more complex examples over time as needed.  The hope is to be able to reduce complexity and duplication on an even larger scale than currently allowed, including (but not limited to):
- importing shared/common code
- looping over entire sections
- taking advantage of defining common values in a single file/location and using those values throughout.

Feedback appreciated.