### PR TITLE
Add a license checker for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ hs_err_pid*
 /.idea/
 /build/
 /out/
+/buildSrc/build/
+/buildSrc/.gradle/
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,16 @@
+import cd.go.plugin.buildsrc.license.NoticeFileGenerator
+import cd.go.plugin.buildsrc.license.TeeRenderer
+import com.github.jk1.license.render.SimpleHtmlReportRenderer
+
+plugins {
+    id "com.github.jk1.dependency-license-report"
+}
+
 group 'cd.go.plugin.config.yaml'
 version '0.8.6'
 
 apply plugin: 'java'
+apply plugin: "com.github.jk1.dependency-license-report"
 
 project.ext.pluginDesc = [
         version    : project.version,
@@ -18,7 +27,7 @@ repositories {
 dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'org.apache.ant', name: 'ant', version: '1.7.1'
+    compile group: 'org.apache.ant', name: 'ant', version: '1.10.5'
     compile group: 'com.beust', name: 'jcommander', version: '1.72'
     compile group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version: '1.13'
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.23'
@@ -82,9 +91,19 @@ jar {
         attributes 'Main-Class': 'cd.go.plugin.config.yaml.cli.YamlPluginCli'
     }
 
+    from(generateLicenseReport) {
+        into "dependency-license-report"
+        exclude "NOTICE.txt"
+    }
+
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 
     exclude "META-INF/*.SF"
     exclude "META-INF/*.DSA"
     exclude "META-INF/*.RSA"
 }
+
+licenseReport {
+    renderers = [new NoticeFileGenerator(new TeeRenderer(new SimpleHtmlReportRenderer()), "${project.buildDir}/reports/dependency-license/")]
+}
+

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'groovy'
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    compile group: 'com.github.jk1.dependency-license-report', name: 'com.github.jk1.dependency-license-report.gradle.plugin', version: '1.3'
+}

--- a/buildSrc/src/main/groovy/cd/go/plugin/buildsrc/license/NoticeFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/cd/go/plugin/buildsrc/license/NoticeFileGenerator.groovy
@@ -1,0 +1,32 @@
+package cd.go.plugin.buildsrc.license
+
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.render.ReportRenderer
+import com.github.jk1.license.render.SingleInfoReportRenderer
+
+class NoticeFileGenerator extends SingleInfoReportRenderer implements ReportRenderer {
+    ReportRenderer toDecorate
+    String licenseFolder
+
+    NoticeFileGenerator(ReportRenderer toDecorate, String licenseFolder) {
+        this.toDecorate = toDecorate;
+        this.licenseFolder = licenseFolder;
+    }
+
+    @Override
+    void render(ProjectData projectData) {
+        toDecorate.render(projectData)
+
+        projectData.allDependencies.collect { data ->
+            def noticeFile = new File(licenseFolder + 'NOTICE.txt')
+            if (!data.licenseFiles.empty) {
+                data.licenseFiles.first().files.collect { file ->
+                    if (new File(file).name.toLowerCase().contains("notice")) {
+                        noticeFile.append(new File(licenseFolder + file).getText('UTF-8'))
+                        noticeFile.append('\n')
+                    }
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/cd/go/plugin/buildsrc/license/TeeRenderer.groovy
+++ b/buildSrc/src/main/groovy/cd/go/plugin/buildsrc/license/TeeRenderer.groovy
@@ -1,0 +1,49 @@
+package cd.go.plugin.buildsrc.license
+
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.render.ReportRenderer
+import com.github.jk1.license.render.SingleInfoReportRenderer
+
+class TeeRenderer extends SingleInfoReportRenderer implements ReportRenderer {
+    ReportRenderer toDecorate
+    def LICENSES = [
+            'Apache License, Version 2.0',
+            'Apache 2.0',
+            'The Apache Software License, Version 2.0',
+            'New BSD License'
+    ]
+
+    TeeRenderer(ReportRenderer toDecorate) {
+        this.toDecorate = toDecorate;
+    }
+
+    @Override
+    void render(ProjectData projectData) {
+        toDecorate.render(projectData)
+
+        def violations = []
+
+        projectData.allDependencies.collect { data ->
+
+            def moduleDesc = "${data.group}:${data.name}:${data.version}"
+
+            if (data.poms.empty) {
+                violations << "POM file for ${moduleDesc} does not contain license information"
+            }
+
+            def pomData = data.poms.first()
+            if (pomData.licenses.empty) {
+                violations << "POM file for ${moduleDesc} does not contain license information"
+            }
+
+            def hasValidLicense = pomData.licenses.any { license -> LICENSES.contains(license.name) }
+            if (!hasValidLicense) {
+                violations << "Unsupported license '${pomData.licenses}', from module '${moduleDesc}'"
+            }
+        }
+
+        if (!violations.empty) {
+            throw new RuntimeException("There were the following errors with enforcing licensing\n${violations.collect { "\t${it}" }.join("\n")}")
+        }
+    }
+}


### PR DESCRIPTION
Should help avoid pulling in any dependencies that are incompatible
with the Apache 2.0 license.

Currently this works on the basis of a whitelist of approved licenses.
See `TeeRenderer.groovy` file for the approved list.