### PR TITLE
Add ability to control display order of pipelines on the GoCD dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,76 +12,76 @@
  * support nested lists of stages \#95
  * added syntax to configure new scms \#109
 
-# 0.8.6 (21 Jan 2019)
+### 0.8.6 (2019-Jan-21)
 
-* Changed JSON keys returned by `get-capabilities` call
-* Changed JSON structure returned by `parse-content` call
-* Implemented a new `get-icon` call that will return the icon for this plugin
+ * Changed JSON keys returned by `get-capabilities` call
+ * Changed JSON structure returned by `parse-content` call
+ * Implemented a new `get-icon` call that will return the icon for this plugin
 
-# 0.8.5 (15 Jan 2019)
+### 0.8.5 (2019-Jan-15)
 
  * return json from CLI command
 
-# 0.8.4 (09 Jan 2019)
+### 0.8.4 (2019-Jan-09)
 
  * Add export content metadata
  * Fix plugin settings request and implement handler for plugin config change notification
 
-# 0.8.3 (03 Jan 2019)
+### 0.8.3 (2019-Jan-03)
 
  * Added support for `parse-content`.
 
-# 0.8.2 (12 Dec 2018)
+### 0.8.2 (2018-Dec-12)
 
  * accept stdin input in cli tool
 
-# 0.8.1 (30 Nov 2018)
+### 0.8.1 (2018-Nov-30)
 
  * adds CLI for syntax checking
  * adds docker image with the CLI to releases
 
-# 0.8.0 (9 Nov 2018)
+### 0.8.0 (2018-Nov-09)
 
  * added inverse transforms and config-repo 2.0 API support
  * updated to gradle 4.10.2
 
-# 0.7.0 (9 Jul 2018)
+### 0.7.0 (2018-Jul-09)
 
  * introduces `format_version: 3` and external fetch task
 
-# 0.6.2 (13 Mar 2018)
+### 0.6.2 (2018-Mar-13)
 
  * fix ability to set custom file pattern per configuration repository
 
-# 0.6.1 (23 Feb 2018)
+### 0.6.1 (2018-Feb-23)
 
  * switch to EsotericSoftware's yamlbeans
 
-# 0.6.0 (26 Oct 2017)
+### 0.6.0 (2017-Oct-26)
 
  * adds support for referencing templates and specifying parameters
  * adds better support for YAML aliases
  * introduces format_version field, with future work for v2 format
 
-# 0.5.0 (15 Sep 2017)
+### 0.5.0 (2017-Sep-15)
 
  * new release build tasks
  * added configrepo material type
  * added p4 material type support
 
-# 0.4.0 (16 Dec 2016)
+### 0.4.0 (2016-Dec-16)
 
  * fixed IO error reporting
  * added elastic_profile_id in job
 
-# 0.3.0 (07 Nov 2016)
+### 0.3.0 (2016-Nov-07)
 
  * added validation of duplicate keys
 
-# 0.2.0 (21 Oct 2016)
+### 0.2.0 (2016-Oct-21)
 
 * added optional `timeout` field to job
 
-# 0.1.0 (16 Jul 2016)
+### 0.1.0 (2016-Jul-16)
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 0.9.2 - Unreleased
+### 0.10.0 (2019-Apr-05)
+
+ * Add support for `display_order` at pipeline level \#114
 
 ### 0.9.1 (2019-Apr-05)
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'cd.go.plugin.config.yaml'
-version "0.9.2"
+version "0.10.0"
 
 apply plugin: 'java'
 apply plugin: "com.github.jk1.dependency-license-report"

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static cd.go.plugin.config.yaml.JSONUtils.addOptionalInt;
 import static cd.go.plugin.config.yaml.JSONUtils.addOptionalValue;
 import static cd.go.plugin.config.yaml.YamlUtils.*;
 import static cd.go.plugin.config.yaml.transforms.EnvironmentVariablesTransform.JSON_ENV_VAR_FIELD;
@@ -26,6 +27,7 @@ public class PipelineTransform {
     private static final String JSON_PIPELINE_TIMER_FIELD = "timer";
     private static final String JSON_PIPELINE_MATERIALS_FIELD = "materials";
     private static final String JSON_PIPELINE_STAGES_FIELD = "stages";
+    private static final String JSON_PIPELINE_DISPLAY_ORDER_FIELD = "display_order_weight";
 
     private static final String YAML_PIPELINE_GROUP_FIELD = "group";
     private static final String YAML_PIPELINE_TEMPLATE_FIELD = "template";
@@ -37,6 +39,7 @@ public class PipelineTransform {
     private static final String YAML_PIPELINE_TIMER_FIELD = "timer";
     private static final String YAML_PIPELINE_MATERIALS_FIELD = "materials";
     private static final String YAML_PIPELINE_STAGES_FIELD = "stages";
+    private static final String YAML_PIPELINE_DISPLAY_ORDER_FIELD = "display_order";
 
     private final MaterialTransform materialTransform;
     private final StageTransform stageTransform;
@@ -65,6 +68,7 @@ public class PipelineTransform {
         Map<String, Object> pipeMap = (Map<String, Object>) entry.getValue();
 
         addOptionalString(pipeline, pipeMap, JSON_PIPELINE_GROUP_FIELD, YAML_PIPELINE_GROUP_FIELD);
+        addOptionalInteger(pipeline, pipeMap, JSON_PIPELINE_DISPLAY_ORDER_FIELD, YAML_PIPELINE_DISPLAY_ORDER_FIELD);
         addOptionalString(pipeline, pipeMap, JSON_PIPELINE_TEMPLATE_FIELD, YAML_PIPELINE_TEMPLATE_FIELD);
         addOptionalString(pipeline, pipeMap, JSON_PIPELINE_LABEL_TEMPLATE_FIELD, YAML_PIPELINE_LABEL_TEMPLATE_FIELD);
         addOptionalBoolean(pipeline, pipeMap, JSON_PIPELINE_PIPE_LOCKING_FIELD, YAML_PIPELINE_PIPE_LOCKING_FIELD);
@@ -106,6 +110,7 @@ public class PipelineTransform {
         addOptionalValue(pipelineMap, pipeline, JSON_PIPELINE_PIPE_LOCKING_FIELD, YAML_PIPELINE_PIPE_LOCKING_FIELD);
         addOptionalValue(pipelineMap, pipeline, JSON_PIPELINE_LOCK_BEHAVIOR_FIELD, YAML_PIPELINE_LOCK_BEHAVIOR_FIELD);
         addOptionalValue(pipelineMap, pipeline, JSON_PIPELINE_TRACKING_TOOL_FIELD, YAML_PIPELINE_TRACKING_TOOL_FIELD);
+        addOptionalInt(pipelineMap, pipeline, JSON_PIPELINE_DISPLAY_ORDER_FIELD, YAML_PIPELINE_DISPLAY_ORDER_FIELD);
 
         addInverseTimer(pipelineMap, pipeline);
 

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformTest.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.internal.LinkedTreeMap;
 import org.junit.Before;
 import org.junit.Test;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,18 +21,15 @@ public class PipelineTransformTest {
 
     private PipelineTransform parser;
     private MaterialTransform materialTransform;
-    private StageTransform stageTransform;
-    private EnvironmentVariablesTransform environmentTransform;
-    private Yaml yaml;
 
     @Before
     public void SetUp() {
         materialTransform = mock(MaterialTransform.class);
-        stageTransform = mock(StageTransform.class);
-        environmentTransform = mock(EnvironmentVariablesTransform.class);
+        StageTransform stageTransform = mock(StageTransform.class);
+        EnvironmentVariablesTransform environmentTransform = mock(EnvironmentVariablesTransform.class);
         ParameterTransform parameterTransform = mock(ParameterTransform.class);
+
         parser = new PipelineTransform(materialTransform, stageTransform, environmentTransform, parameterTransform);
-        yaml = new Yaml();
     }
 
     @Test
@@ -61,11 +57,26 @@ public class PipelineTransformTest {
     }
 
     @Test
+    public void shouldTransformAPipelineWhichHasADisplayOrderWeight() throws IOException {
+        testTransform("display_order.pipe");
+    }
+
+    @Test
     public void shouldInverseTransformPipeline() throws IOException {
-        Map<String, Object> mats = new LinkedTreeMap<>();
-        mats.put("foo", new LinkedTreeMap<>());
-        when(materialTransform.inverseTransform(any(LinkedTreeMap.class))).thenReturn(mats);
+        Map<String, Object> materials = new LinkedTreeMap<>();
+        materials.put("foo", new LinkedTreeMap<>());
+        when(materialTransform.inverseTransform(any(LinkedTreeMap.class))).thenReturn(materials);
+
         testInverseTransform("export.pipe");
+    }
+
+    @Test
+    public void shouldInverseTransformAPipelineWhichHasADisplayOrderWeight() throws IOException {
+        Map<String, Object> materials = new LinkedTreeMap<>();
+        materials.put("foo", new LinkedTreeMap<>());
+        when(materialTransform.inverseTransform(any(LinkedTreeMap.class))).thenReturn(materials);
+
+        testInverseTransform("display_order.pipe");
     }
 
     private void testTransform(String caseFile) throws IOException {

--- a/src/test/resources/parts/display_order.pipe.json
+++ b/src/test/resources/parts/display_order.pipe.json
@@ -1,0 +1,12 @@
+{
+  "name": "pipe1",
+  "group": "group1",
+  "display_order_weight": 10,
+  "materials": [
+    null
+  ],
+  "stages": [
+    null,
+    null
+  ]
+}

--- a/src/test/resources/parts/display_order.pipe.yaml
+++ b/src/test/resources/parts/display_order.pipe.yaml
@@ -1,0 +1,8 @@
+pipe1:
+  group: group1
+  display_order: 10
+  materials:
+    foo: {}
+  stages:
+    - null
+    - null


### PR DESCRIPTION
* Introduce display_order_weight.
* Update README to reflect that a UI is now available to configure config repositories.
* Clarify usage of format_version.
* Code changes and tests.

@tomzo Haven't bumped the version, since this is at 0.9.0 already. Do you want: `0.10.0`? `1.0.0`? Wasn't sure.

Related to https://github.com/gocd/gocd/pull/6043