### PR TITLE
Fix pipeline export of external artifacts

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/transforms/ConfigurationTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/ConfigurationTransform.java
@@ -9,12 +9,12 @@ import java.util.Map;
 
 public class ConfigurationTransform {
 
-    public static final String YAML_PLUGIN_STD_CONFIG_FIELD = "options";
-    public static final String YAML_PLUGIN_SEC_CONFIG_FIELD = "secure_options";
-    private static final String JSON_PLUGIN_CONFIG_KEY_FIELD = "key";
-    private static final String JSON_PLUGIN_CONFIG_VALUE_FIELD = "value";
-    private static final String JSON_PLUGIN_CONFIG_ENCRYPTED_VALUE_FIELD = "encrypted_value";
-    private static final String JSON_PLUGIN_CONFIGURATION_FIELD = "configuration";
+    static final String YAML_PLUGIN_STD_CONFIG_FIELD = "options";
+    static final String YAML_PLUGIN_SEC_CONFIG_FIELD = "secure_options";
+    static final String JSON_PLUGIN_CONFIG_KEY_FIELD = "key";
+    static final String JSON_PLUGIN_CONFIG_VALUE_FIELD = "value";
+    static final String JSON_PLUGIN_CONFIG_ENCRYPTED_VALUE_FIELD = "encrypted_value";
+    static final String JSON_PLUGIN_CONFIGURATION_FIELD = "configuration";
 
     void addConfiguration(JsonObject json, Map<String, Object> configurationMap) {
         if (configurationMap == null) {

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/JobTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/JobTransformTest.java
@@ -8,11 +8,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Function;
 
 import static cd.go.plugin.config.yaml.TestUtils.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class JobTransformTest {
     private EnvironmentVariablesTransform environmentTransform;
@@ -50,16 +52,16 @@ public class JobTransformTest {
 
     @Test
     public void shouldTransformExternalArtifactConfig() throws IOException {
+        useParserWithoutMocks();
+
         testTransform("external_artifacts");
     }
 
     @Test
     public void shouldTransformJobWithListOfListsTasks() throws IOException {
-        environmentTransform = new EnvironmentVariablesTransform();
-        taskTransform = new TaskTransform();
-        parser = new JobTransform(environmentTransform, taskTransform);
+        useParserWithoutMocks();
 
-        JsonObject job = testTransform("list_of_lists_tasks");
+        testTransform("list_of_lists_tasks");
     }
 
     @Test
@@ -85,6 +87,19 @@ public class JobTransformTest {
     @Test
     public void shouldInverseTransformElasticProfileJob() throws IOException {
         testInverseTransform("elastic_profile");
+    }
+
+    @Test
+    public void shouldInverseTransformExternalArtifactConfig() throws IOException {
+        useParserWithoutMocks();
+
+        testInverseTransform("external_artifacts");
+    }
+
+    private void useParserWithoutMocks() {
+        environmentTransform = new EnvironmentVariablesTransform();
+        taskTransform = new TaskTransform();
+        parser = new JobTransform(environmentTransform, taskTransform);
     }
 
     private JsonObject testTransform(String caseFile) throws IOException {

--- a/src/test/resources/parts/jobs/external_artifacts.json
+++ b/src/test/resources/parts/jobs/external_artifacts.json
@@ -26,5 +26,11 @@
         }
       ]
     }
+  ],
+  "tasks": [
+    {
+      "type": "exec",
+      "command": "make"
+    }
   ]
 }

--- a/src/test/resources/parts/jobs/external_artifacts.yaml
+++ b/src/test/resources/parts/jobs/external_artifacts.yaml
@@ -1,6 +1,4 @@
 test:
-  tasks:
-    - null
   artifacts:
     - build:
         source: src1
@@ -16,3 +14,6 @@ test:
             white_russian: "cocktail"
           secure_options:
             fermented_coffee: "sfsggge124#"
+  tasks:
+    - exec:
+        command: make


### PR DESCRIPTION
Fixes https://github.com/gocd/gocd/issues/6038

The conversion is a little weird. This needs to get converted:

```json
{
  "type": "external",
  "id": "docker-release-candidate",
  "store_id": "dockerhub",
  "configuration": [
    {
      "key": "Image",
      "value": "gocd/gocd-demo"
    },
    {
      "key": "Tag",
      "value": "Tag1"
    },
    {
      "key": "some_secure_property",
      "encrypted_value": "!@ESsdD323#sdu"
    }
  ]
}
```

... to ...

```yaml
external:
    id: docker-release-candidate
    store_id: dockerhub
    configuration:
        options:
            Image: gocd/gocd-demo
            Tag: Tag1
        secure_options:
            some_secure_property: !@ESsdD323#sdu
```

So: From a `List<Map<String, String>>` to `Map<String, Map<String, String>>` with `options` and `secure_options` being the keys.