### PR TITLE
switch build system to use open source openjdk-dojo image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,16 @@
-language: java
+sudo: required
+language: minimal
+services:
+  - docker
+
+env:
+  - DOJO_VERSION=0.4.0
+
+before_install:
+  - sudo rm -f /usr/bin/dojo
+  - wget -O dojo https://github.com/ai-traders/dojo/releases/download/${DOJO_VERSION}/dojo_linux_amd64
+  - sudo mv dojo /usr/local/bin
+  - sudo chmod +x /usr/local/bin/dojo
+
+script:
+ - ./tasks.sh build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 0.10.1 - Unreleased
+### 0.10.1 (2019-Apr-28)
+
+ * switch build system to use open source openjdk-dojo image \#17574
 
 ### 0.10.0 (2019-Apr-05)
 

--- a/Dojofile
+++ b/Dojofile
@@ -1,0 +1,1 @@
+DOJO_DOCKER_IMAGE=kudulab/openjdk-dojo:1.0.1

--- a/Idefile
+++ b/Idefile
@@ -1,1 +1,0 @@
-IDE_DOCKER_IMAGE=docker-registry.ai-traders.com/java-ide:0.5.0

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2019 Tomasz Sętkowski
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1156,3 +1156,20 @@ There are [examples of yaml partials](src/test/resources/parts) and
  their resulting json to be sent to GoCD server. If something is not working right
  we can always add a new case covering exact yaml that user has and json that we
  expect on server side.
+
+
+# License
+
+Copyright 2019 Tomasz Sętkowski
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1110,9 +1110,33 @@ pipelines:
 
 # Development
 
-Run all tests and create a ready to use jar
+## Environment setup
+
+To build and test this plugin, you'll need java jdk >= 8.
+
+If you have local java environment, then you may run all tests and create a ready to use jar with:
 ```bash
 ./gradlew test jar
+```
+
+## Building with docker and dojo
+
+You don't need to setup java on your host, if you are fine with using docker and [Dojo](https://github.com/ai-traders/dojo).
+This is actually how our GoCD builds the plugin:
+```
+dojo "gradle test jar"
+```
+
+Assuming you already have a working docker, you can install dojo with:
+```
+DOJO_VERSION=0.4.0
+wget -O dojo https://github.com/ai-traders/dojo/releases/download/${DOJO_VERSION}/dojo_linux_amd64
+sudo mv dojo /usr/local/bin
+sudo chmod +x /usr/local/bin/dojo
+```
+Then enter a docker container with java and gradle pre-installed, by running following command at the root of the project:
+```
+dojo
 ```
 
 ## Versioning

--- a/ci.gocd.yaml
+++ b/ci.gocd.yaml
@@ -1,3 +1,4 @@
+format_version: 3
 pipelines:
   "gocd-yaml-plugin":
     group: gocd
@@ -16,9 +17,10 @@ pipelines:
                destination: build/libs
           tasks:
            - exec:
-               command: ide
+               command: bash
                arguments:
-                - gradle test jar
+                - -c
+                - ./tasks.sh build
       - docker:
           clean_workspace: true
           resources:

--- a/tasks.sh
+++ b/tasks.sh
@@ -47,6 +47,9 @@ case "${command}" in
     set_version_in_changelog "${changelog_file}" "${next_version}" "false"
     set_version_in_file "version " "build.gradle" "${next_version}"
     ;;
+  build)
+    dojo "gradle test jar"
+    ;;
   build_docker)
     changelog_version=$(get_last_version_from_changelog "${changelog_file}")
     docker_build_options="--build-arg this_image_tag_arg=${changelog_version}"


### PR DESCRIPTION
All builds (public on travis and GoCD) will execute in same [docker image](https://github.com/kudulab/docker-openjdk-dojo) using [Dojo](https://github.com/ai-traders/dojo) from now on.