### PR TITLE
support for username and encrypted_password / password field for git and hg material

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Please note that it is now recommended to declare `format_version` in each `gocd
 
 #### GoCD server version from 19.4.0 and beyond
 
-Supports `format_version` value of `5`. In this version, support of `username` and `encrypted_password` for [git](#git-material-update) and [hg](#hg-material-update) material has been added.
+Supports `format_version` value of `5`. In this version, support of `username` and `encrypted_password` for [git](#git-material-update) and [hg](#hg-material-update) material has been added. In addition to that, [hg](#hg-material-update) will also support `branch` attribute.
 
 Using a newer `format_version` includes all the behavior of the previous versions too.
 
@@ -691,7 +691,7 @@ gitMaterial1:
 
 For **GoCD >= 19.4.0 and `format_version: 5` and above**:
 
-You need to specify `username` and `encrypted_password` explicitly as such
+You are advised to utilize `username` and `encrypted_password` for passing in material credentials as:
 ```yaml
 gitMaterial1:
   git: "http://my.git.repository.com"
@@ -699,7 +699,7 @@ gitMaterial1:
   username: my_username
   encrypted_password: encrypted_value
 ```
-Instead of `encrypted_password` you can specify `password`.
+Instead of `encrypted_password` you may specify `password` but `encrypted_password` makes more sense considering that the value is stored in SCM.
 
 ### Svn
 
@@ -728,19 +728,32 @@ hgMaterial1:
     - tools
   destination: dir1
   auto_update: false
+  username: my_username
+  encrypted_password: encrypted_value
+  branch: feature
 ```
 <a name="hg-material-update"/>
 
 For **GoCD >= 19.4.0 and `format_version: 5` and above**:
 
-You need to specify `username` and `encrypted_password` explicitly as such
+You are advised to utilize `username` and `encrypted_password` for passing in material credentials as:
 ```yaml
 hgMaterial1:
   hg: repos/myhg
   username: my_username
   encrypted_password: encrypted_value
 ```
-Instead of `encrypted_password` you can specify `password`.
+Instead of `encrypted_password` you may specify `password` but `encrypted_password` makes more sense considering that the value is stored in SCM.
+
+
+In addition to that, you can also leverage `branch` attribute to specify the branch for material
+
+```yaml
+hgMaterial1:
+  hg: repos/myhg
+  branch: feature
+```
+
 
 ### Perforce
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ More examples are in [test resources](src/test/resources/examples/).
 
 ```yaml
 #ci.gocd.yaml
-format_version: 4
+format_version: 5
 environments:
   testing:
     environment_variables:
@@ -257,7 +257,21 @@ Feel free to improve it!
 
 Please note that it is now recommended to declare `format_version` in each `gocd.yaml` file, consistent across all your files.
 
-#### GoCD server version from 19.3.0 and beyond
+#### GoCD server version from 19.4.0 and beyond
+
+Supports `format_version` value of `5`. In this version, support of `username` and `encrypted_password` for [git](#git-material-update) and [hg](#hg-material-update) material has been added.
+
+Using a newer `format_version` includes all the behavior of the previous versions too.
+
+```yaml
+format_version: 5
+pipelines:
+  ...
+environments:
+```
+
+
+#### GoCD server version 19.3.0
 
 Supports `format_version` value of `4`. In this version, support has been added to control the [display order of pipelines](#display-order-of-pipelines).
 
@@ -673,6 +687,20 @@ gitMaterial1:
     - src/**/*.*
 ```
 
+<a name="git-material-update"/>
+
+For **GoCD >= 19.4.0 and `format_version: 5` and above**:
+
+You need to specify `username` and `encrypted_password` explicitly as such
+```yaml
+gitMaterial1:
+  git: "http://my.git.repository.com"
+  branch: feature12
+  username: my_username
+  encrypted_password: encrypted_value
+```
+Instead of `encrypted_password` you can specify `password`.
+
 ### Svn
 
 For details about each option, see [GoCD XML reference](https://docs.gocd.org/current/configuration/configuration_reference.html#svn)
@@ -680,7 +708,7 @@ For details about each option, see [GoCD XML reference](https://docs.gocd.org/cu
 svnMaterial1:
   svn: "http://svn"
   username: "user1"
-  password: "pass1"
+  encrypted_password: "encrypted_value"
   check_externals: true
   blacklist:
     - tools
@@ -688,6 +716,7 @@ svnMaterial1:
   destination: destDir1
   auto_update: false
 ```
+Instead of `encrypted_password` you can specify `password`.
 
 ### Hg
 
@@ -700,6 +729,18 @@ hgMaterial1:
   destination: dir1
   auto_update: false
 ```
+<a name="hg-material-update"/>
+
+For **GoCD >= 19.4.0 and `format_version: 5` and above**:
+
+You need to specify `username` and `encrypted_password` explicitly as such
+```yaml
+hgMaterial1:
+  hg: repos/myhg
+  username: my_username
+  encrypted_password: encrypted_value
+```
+Instead of `encrypted_password` you can specify `password`.
 
 ### Perforce
 
@@ -707,7 +748,7 @@ hgMaterial1:
 p4Material1:
   p4: "host.domain.com:12345"
   username: johndoe
-  password: pass
+  encrypted_password: encrypted_value
   use_tickets: false
   view: |
     //depot/external... //ws/external...
@@ -718,7 +759,7 @@ p4Material1:
   auto_update: false
 ```
 
-Instead of `password` you can use `encrypted_password`.
+Instead of `encrypted_password` you can specify `password`.
 
 ### Tfs
 

--- a/README.md
+++ b/README.md
@@ -699,7 +699,15 @@ gitMaterial1:
   username: my_username
   encrypted_password: encrypted_value
 ```
-Instead of `encrypted_password` you may specify `password` but `encrypted_password` makes more sense considering that the value is stored in SCM.
+
+- Instead of `encrypted_password` you may specify `password` but `encrypted_password` makes more sense considering that the value is stored in SCM.
+- Specifying credentials both in `attributes` and `url` will result in a validation error e.g.
+  ```log
+    INVALID MERGED CONFIGURATION
+    Number of errors: 1+
+    1. Ambiguous credentials, must be provided either in URL or as attributes.;;
+    - For Config Repo: https://your.config.repo.url at cbb047d78c239ab23b9565099e800c6fe4cc0anc
+  ```
 
 ### Svn
 
@@ -743,8 +751,15 @@ hgMaterial1:
   username: my_username
   encrypted_password: encrypted_value
 ```
-Instead of `encrypted_password` you may specify `password` but `encrypted_password` makes more sense considering that the value is stored in SCM.
 
+- Instead of `encrypted_password` you may specify `password` but `encrypted_password` makes more sense considering that the value is stored in SCM.
+- Specifying credentials both in `attributes` and `url` will result in a validation error e.g.
+  ```log
+    INVALID MERGED CONFIGURATION
+    Number of errors: 1+
+    1. Ambiguous credentials, must be provided either in URL or as attributes.;;
+    - For Config Repo: https://your.config.repo.url at cbb047d78c239ab23b9565099e800c6fe4cc0anc
+  ```
 
 In addition to that, you can also leverage `branch` attribute to specify the branch for material
 

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
@@ -75,6 +75,11 @@ public class MaterialTransformTest {
     }
 
     @Test
+    public void shouldTransformHgWhenBranchIsPresent() throws IOException {
+        testTransform("branch.hg");
+    }
+
+    @Test
     public void shouldTransformSimpleDependency() throws IOException {
         testTransform("simple.dependency");
     }

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
@@ -40,6 +40,11 @@ public class MaterialTransformTest {
     }
 
     @Test
+    public void shouldTransformGitWhenPlainPassword() throws IOException {
+        testTransform("password.git");
+    }
+
+    @Test
     public void shouldTransformCompleteGit() throws IOException {
         testTransform("complete.git");
     }
@@ -62,6 +67,11 @@ public class MaterialTransformTest {
     @Test
     public void shouldTransformCompleteHg() throws IOException {
         testTransform("complete.hg");
+    }
+
+    @Test
+    public void shouldTransformHgWhenPlainPassword() throws IOException {
+        testTransform("password.hg");
     }
 
     @Test

--- a/src/test/resources/parts/materials/branch.hg.json
+++ b/src/test/resources/parts/materials/branch.hg.json
@@ -1,0 +1,4 @@
+{
+  "url": "repos/myhg",
+  "branch": "feature"
+}

--- a/src/test/resources/parts/materials/branch.hg.yaml
+++ b/src/test/resources/parts/materials/branch.hg.yaml
@@ -1,0 +1,3 @@
+hgMaterial1:
+  hg: repos/myhg
+  branch: feature

--- a/src/test/resources/parts/materials/complete.git.json
+++ b/src/test/resources/parts/materials/complete.git.json
@@ -3,6 +3,8 @@
   "type": "git",
   "url": "http://my.git.repository.com",
   "branch": "feature12",
+  "username": "username",
+  "encrypted_password": "some encrypted value",
   "filter": {
     "ignore": [
       "externals",

--- a/src/test/resources/parts/materials/complete.git.yaml
+++ b/src/test/resources/parts/materials/complete.git.yaml
@@ -1,5 +1,7 @@
 gitMaterial1:
   git: "http://my.git.repository.com"
+  username: "username"
+  encrypted_password: "some encrypted value"
   branch: "feature12"
   blacklist:
     - externals

--- a/src/test/resources/parts/materials/complete.hg.json
+++ b/src/test/resources/parts/materials/complete.hg.json
@@ -1,5 +1,7 @@
 {
   "url": "repos/myhg",
+  "username": "username",
+  "encrypted_password": "some encrypted value",
   "filter": {
     "ignore": [
       "externals",

--- a/src/test/resources/parts/materials/complete.hg.yaml
+++ b/src/test/resources/parts/materials/complete.hg.yaml
@@ -1,5 +1,7 @@
 hgMaterial1:
   hg: repos/myhg
+  username: username
+  encrypted_password: some encrypted value
   blacklist:
     - externals
     - tools

--- a/src/test/resources/parts/materials/password.git.json
+++ b/src/test/resources/parts/materials/password.git.json
@@ -1,0 +1,8 @@
+{
+  "name": "gitMaterial1",
+  "type": "git",
+  "url": "http://my.git.repository.com",
+  "branch": "feature12",
+  "username": "some username",
+  "password": "some password"
+}

--- a/src/test/resources/parts/materials/password.git.yaml
+++ b/src/test/resources/parts/materials/password.git.yaml
@@ -1,0 +1,5 @@
+gitMaterial1:
+  git: "http://my.git.repository.com"
+  username: "some username"
+  password: "some password"
+  branch: "feature12"

--- a/src/test/resources/parts/materials/password.hg.json
+++ b/src/test/resources/parts/materials/password.hg.json
@@ -1,0 +1,5 @@
+{
+  "url": "repos/myhg",
+  "username": "some username",
+  "password": "some password"
+}

--- a/src/test/resources/parts/materials/password.hg.yaml
+++ b/src/test/resources/parts/materials/password.hg.yaml
@@ -1,0 +1,4 @@
+hgMaterial1:
+  hg: repos/myhg
+  username: some username
+  password: some password


### PR DESCRIPTION
**This should not be merged until 19.4.0 is merged as the contract won't be released until then.**

- Document `format_version 5` - support for `username` and `encrypted_password / password` field while specifying git and hg material.
- Updated test cases

GoCD issue for reference: [#6132](https://github.com/gocd/gocd/issues/6132)
