### PR TITLE
Fix the inverse transform test for MaterialTransform

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
@@ -45,6 +45,7 @@ public class MaterialTransform extends ConfigurationTransform {
     public MaterialTransform() {
         yamlSpecialKeywords.add(YAML_SHORT_KEYWORD_GIT);
         // TODO all other transforms
+        yamlSpecialKeywords.add("name");
         yamlSpecialKeywords.add("type");
         yamlSpecialKeywords.add("auto_update");
         yamlSpecialKeywords.add("shallow_clone");

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
@@ -1,6 +1,7 @@
 package cd.go.plugin.config.yaml.transforms;
 
 import cd.go.plugin.config.yaml.JsonObjectMatcher;
+import cd.go.plugin.config.yaml.YamlUtils;
 import com.google.gson.JsonObject;
 import org.junit.Test;
 
@@ -9,7 +10,6 @@ import java.util.Map;
 
 import static cd.go.plugin.config.yaml.TestUtils.*;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class MaterialTransformTest {
@@ -175,8 +175,8 @@ public class MaterialTransformTest {
     }
 
     private void testInverseTransform(String caseFile, String expectedFile) throws IOException {
+        String expectedObject = loadString("parts/materials/" + expectedFile + ".yaml");
         Map<String, Object> actual = parser.inverseTransform(readJsonGson("parts/materials/" + caseFile + ".json"));
-        JsonObject transform = parser.transform(actual);
-        assertEquals((readJsonObject("parts/materials/" + expectedFile + ".json")), transform);
+        assertYamlEquivalent(expectedObject, YamlUtils.dump(actual));
     }
 }

--- a/src/test/resources/parts/materials/complete.p4.yaml
+++ b/src/test/resources/parts/materials/complete.p4.yaml
@@ -3,7 +3,7 @@ p4Material1:
   username: johndoe
   password: pass
   use_tickets: false
-  view: |
+  view: |-
     //depot/external... //ws/external...
     //depot/tools... //ws/external...
   blacklist:

--- a/src/test/resources/parts/materials/complete.scm.json
+++ b/src/test/resources/parts/materials/complete.scm.json
@@ -15,5 +15,6 @@
     ]
   },
   "name": "myPluggableGit",
-  "type": "plugin"
+  "type": "plugin",
+  "scm_id": "myScmId"
 }

--- a/src/test/resources/parts/materials/complete.scm.yaml
+++ b/src/test/resources/parts/materials/complete.scm.yaml
@@ -1,10 +1,11 @@
 myPluggableGit:
+  scm: myScmId
   plugin_configuration:
     id: plugin_id
-    version: 1
-  destination: destinationDir
+    version: "1"
   options:
     url: url
   blacklist:
     - dir1
     - dir2
+  destination: destinationDir


### PR DESCRIPTION
The test was comparing a json file to itself. Fixed it to read the yaml file, inverse-transform it, and compare it with the json file.

This caught a few issues in the json and yaml files -
- complete.p4.yaml - needed block chomping for the multiline string
- complete.scm.yaml - scmId is required, which was missing. Had to change the order of some fields, because we are comparing LinkedHashMaps in the test. As such, the order shouldn't matter in the yaml unless its a sequence.
