### PR TITLE
Support for ignore_for_scheduling flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 0.11.3 - Unreleased
+### 0.12.0 (2019-Oct-01)
+
+* Added support for `ignore_for_scheduling` to dependency materials. Updated README with changes in new Format Versions.
 
 ### 0.11.2 (2019-Aug-22)
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,26 @@ Feel free to improve it!
 
 Please note that it is now recommended to declare `format_version` in each `gocd.yaml` file, consistent across all your files.
 
+#### GoCD server verison from 19.10.0 and beyond
+
+Supports `format_version` value of `9`. In this version, support of `ignore_for_scheduling` for [dependency materials](#dependency) has been added. Setting this attribute will skip scheduling the pipeline when the dependency material has changed.
+
+Using a newer `format_version` includes all the behavior of the previous versions too.
+
+```yaml
+format_version: 9
+pipelines:
+  ...
+environments:
+```
+
+#### GoCD server version from 19.9.0 and beyond
+
+Supports `format_version` value of `7` and `8`. In version `7`, support for [properties](#property) has been removed. In version `8`, support for `mingle` as a [tracking tool](#tracking-tool) has been removed.
+
+Using a newer `format_version` includes all the behavior of the previous versions too.
+
+
 #### GoCD server verison from 19.8.0 and beyond
 
 Supports `format_version` value of `6`. In this version, support of `allow_only_on_success` attribute for [approval](#approval) in stage has been added. Setting this attribute to `true` will allow the stage to be manually triggered only if the previous stage has passed successfully.
@@ -511,10 +531,6 @@ test:
             Tag: v${GO_PIPELINE_LABEL}
           secure_options:
             some_secure_property: "!@ESsdD323#sdu"
-  properties:
-    perf:
-      source: test.xml
-      xpath: "substring-before(//report/data/all/coverage[starts-with(@type,\u0027class\u0027)]/@value, \u0027%\u0027)"
   tasks:
     ...
 ```
@@ -603,6 +619,7 @@ tabs:
 ```
 
 ### Property
+**Note: Since GoCD version 19.9 and format_version 7, properties are no longer supported**
 
 Job can have properties, declared as a hash:
 ```yaml
@@ -854,6 +871,7 @@ To add a dependency on another pipeline stage:
 mydependency:
   pipeline: upstream-pipeline-1
   stage: test
+  ignore_for_scheduling: false
 ```
 
 **Note: `mydependency` is the name of material - it must be unique**

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'cd.go.plugin.config.yaml'
-version "0.11.3"
+version "0.12.0"
 
 apply plugin: 'java'
 apply plugin: "com.github.jk1.dependency-license-report"

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
@@ -18,10 +18,12 @@ public class MaterialTransform extends ConfigurationTransform {
     public static final String JSON_MATERIAL_AUTO_UPDATE_FIELD = "auto_update";
     public static final String JSON_MATERIAL_SHALLOW_CLONE_FIELD = "shallow_clone";
     public static final String JSON_MATERIAL_SCM_PLUGIN_CONFIG_FIELD = "plugin_configuration";
+    public static final String JSON_MATERIAL_IGNORE_FOR_SCHEDULING_FIELD = "ignore_for_scheduling";
 
     public static final String YAML_MATERIAL_TYPE_FIELD = "type";
     public static final String YAML_MATERIAL_AUTO_UPDATE_FIELD = "auto_update";
     public static final String YAML_MATERIAL_SHALLOW_CLONE_FIELD = "shallow_clone";
+    public static final String YAML_MATERIAL_IGNORE_FOR_SCHEDULING_FIELD = "ignore_for_scheduling";
 
     public static final String YAML_SHORT_KEYWORD_GIT = "git";
     //TODO others
@@ -59,6 +61,7 @@ public class MaterialTransform extends ConfigurationTransform {
         yamlSpecialKeywords.add("use_tickets");
         yamlSpecialKeywords.add(YAML_SHORT_KEYWORD_PACKAGE_ID);
         yamlSpecialKeywords.add(YAML_SHORT_KEYWORD_SCM_ID);
+        yamlSpecialKeywords.add(YAML_MATERIAL_IGNORE_FOR_SCHEDULING_FIELD);
     }
 
     public JsonObject transform(Object maybeMaterial) {
@@ -114,6 +117,8 @@ public class MaterialTransform extends ConfigurationTransform {
         addOptionalValue(materialdata, material, JSON_MATERIAL_CHECK_EXTERNALS_FIELD, YAML_MATERIAL_CHECK_EXTERNALS_FIELD);
         addOptionalValue(materialdata, material, JSON_MATERIAL_AUTO_UPDATE_FIELD, YAML_MATERIAL_AUTO_UPDATE_FIELD);
 
+        addOptionalValue(materialdata, material, JSON_MATERIAL_IGNORE_FOR_SCHEDULING_FIELD, YAML_MATERIAL_IGNORE_FOR_SCHEDULING_FIELD);
+
 
         // copy all other members
         for (Map.Entry<String, Object> materialProp : material.entrySet()) {
@@ -141,6 +146,7 @@ public class MaterialTransform extends ConfigurationTransform {
         addOptionalBoolean(material, materialMap, JSON_MATERIAL_SHALLOW_CLONE_FIELD, YAML_MATERIAL_SHALLOW_CLONE_FIELD);
         addOptionalBoolean(material, materialMap, JSON_MATERIAL_CHECK_EXTERNALS_FIELD, YAML_MATERIAL_CHECK_EXTERNALS_FIELD);
         addOptionalBoolean(material, materialMap, JSON_MATERIAL_USE_TICKETS_FIELD, YAML_MATERIAL_USE_TICKETS_FIELD);
+        addOptionalBoolean(material, materialMap, JSON_MATERIAL_IGNORE_FOR_SCHEDULING_FIELD, YAML_MATERIAL_IGNORE_FOR_SCHEDULING_FIELD);
         if (materialMap.containsKey("blacklist"))
             addFilter(material, materialMap.get("blacklist"), "ignore");
         if (materialMap.containsKey("whitelist"))

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
@@ -85,6 +85,11 @@ public class MaterialTransformTest {
     }
 
     @Test
+    public void shouldTransformDependencyWithIgnoreForSchedulingFlag() throws IOException {
+        testTransform("ignore_for_scheduling.dependency");
+    }
+
+    @Test
     public void shouldTransformCompletePluggable() throws IOException {
         testTransform("complete.pluggable");
     }
@@ -143,6 +148,11 @@ public class MaterialTransformTest {
     @Test
     public void shouldInverseTransformSimpleDependency() throws IOException {
         testInverseTransform("simple.dependency");
+    }
+
+    @Test
+    public void shouldInverseTransformDependencyWithIgnoreForSchedulingFlag() throws IOException {
+        testInverseTransform("ignore_for_scheduling.dependency");
     }
 
     @Test

--- a/src/test/resources/parts/materials/ignore_for_scheduling.dependency.json
+++ b/src/test/resources/parts/materials/ignore_for_scheduling.dependency.json
@@ -1,0 +1,7 @@
+{
+  "type": "dependency",
+  "name": "upstream",
+  "pipeline": "upstream-pipeline-1",
+  "stage": "test",
+  "ignore_for_scheduling": true
+}

--- a/src/test/resources/parts/materials/ignore_for_scheduling.dependency.yaml
+++ b/src/test/resources/parts/materials/ignore_for_scheduling.dependency.yaml
@@ -1,0 +1,4 @@
+upstream:
+  pipeline: upstream-pipeline-1
+  stage: test
+  ignore_for_scheduling: true


### PR DESCRIPTION
- Added support for `ignore_for_scheduling` flag to dependency materials
- Updated the readme with new format versions, documented removal of `properties` and `mingle`
- Bumped up the minor version

Related PR on GoCD https://github.com/gocd/gocd/pull/7028