### PR TITLE
Fix for export of pipelines with multiple materials without name #144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 0.12.1 - Unreleased
 
+* Fix for pipeline export with multiple materials without name, #144
+
 ### 0.12.0 (2019-Oct-02)
 
 * Added support for `ignore_for_scheduling` to dependency materials. Updated README with changes in new Format Versions.

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 import static cd.go.plugin.config.yaml.JSONUtils.addOptionalValue;
 import static cd.go.plugin.config.yaml.YamlUtils.*;
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
 
 public class MaterialTransform extends ConfigurationTransform {
 
@@ -130,7 +132,8 @@ public class MaterialTransform extends ConfigurationTransform {
         }
 
         if (materialName == null) {
-            inverseMaterial.put(materialType, materialdata);
+            String randomName = format("%s-%s", materialType, randomUUID().toString().substring(0, 7));
+            inverseMaterial.put(randomName, materialdata);
         } else {
             inverseMaterial.put(materialName, materialdata);
         }

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/MaterialTransformTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static cd.go.plugin.config.yaml.TestUtils.*;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -168,6 +169,14 @@ public class MaterialTransformTest {
     @Test
     public void shouldInverseTRansformCompletePluggable() throws IOException {
         testInverseTransform("complete.pluggable");
+    }
+
+    @Test
+    public void inverseTransform_shouldGenerateARandomMaterialNameInAbsenceOfName() {
+        Map<String, Object> material = parser.inverseTransform(readJsonGson("parts/materials/material_without_name.git.json"));
+
+        String materialName = material.keySet().stream().findFirst().get();
+        assertThat(materialName, containsString("git-"));
     }
 
     private void testTransform(String caseFile) throws IOException {

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformTest.java
@@ -21,13 +21,16 @@ public class PipelineTransformTest {
 
     private PipelineTransform parser;
     private MaterialTransform materialTransform;
+    private StageTransform stageTransform;
+    private EnvironmentVariablesTransform environmentTransform;
+    private ParameterTransform parameterTransform;
 
     @Before
     public void SetUp() {
         materialTransform = mock(MaterialTransform.class);
-        StageTransform stageTransform = mock(StageTransform.class);
-        EnvironmentVariablesTransform environmentTransform = mock(EnvironmentVariablesTransform.class);
-        ParameterTransform parameterTransform = mock(ParameterTransform.class);
+        stageTransform = mock(StageTransform.class);
+        environmentTransform = mock(EnvironmentVariablesTransform.class);
+        parameterTransform = mock(ParameterTransform.class);
 
         parser = new PipelineTransform(materialTransform, stageTransform, environmentTransform, parameterTransform);
     }
@@ -77,6 +80,15 @@ public class PipelineTransformTest {
         when(materialTransform.inverseTransform(any(LinkedTreeMap.class))).thenReturn(materials);
 
         testInverseTransform("display_order.pipe");
+    }
+
+    @Test
+    public void inverseTransform_shouldHandleMultipleMaterialsWithoutNames() {
+        parser = new PipelineTransform(new MaterialTransform(), stageTransform, environmentTransform, parameterTransform);
+
+        Map<String, Object> pipeline = parser.inverseTransform(readJsonGson("parts/pipeline_with_multiple_materials.json"));
+
+        assertThat(((Map)((Map)pipeline.get("pipe1")).get("materials")).size(), is(2));
     }
 
     private void testTransform(String caseFile) throws IOException {


### PR DESCRIPTION
* Exporting a pipeline with multiple materials without a name would
  result in yaml without all the materials, this commit fixes this
  issue.


