### PR TITLE
Update reference example for plugin material

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,8 @@ myPluggableGit:
     version: 1 #plugin version
   options:
     url: git@github.com:tomzo/gocd-yaml-config-plugin.git
+  secure_options:
+    password: "encrypted_value"
   destination: destinationDir
   blacklist:
     - dir1


### PR DESCRIPTION
 - Updated the example to showcase configuring a secure configuration property.

I was testing some feature related to plugin materials and had to configure a secure field. Initially I thought of passing the encrypted_value in the options itself. But that was treated as value.
Found the `secure_options` field after going through the code and seeing the example of configuring pluggable tasks.

Raising this PR so that it is easier for other users.