### PR TITLE
use newer openjdk Dojo image kudulab/openjdk-dojo:1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 0.13.1 - Unreleased
+### 0.13.2 (2020-Dec-09)
+
+* use newer openjdk Dojo image kudulab/openjdk-dojo:1.4.1
 
 ### 0.13.0 (2020-Sep-11)
 

--- a/Dojofile
+++ b/Dojofile
@@ -1,1 +1,1 @@
-DOJO_DOCKER_IMAGE=kudulab/openjdk-dojo:1.4.0
+DOJO_DOCKER_IMAGE=kudulab/openjdk-dojo:1.4.1

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'cd.go.plugin.config.yaml'
-version "0.13.1"
+version "0.13.2"
 
 apply plugin: 'java'
 apply plugin: "com.github.jk1.dependency-license-report"


### PR DESCRIPTION
This PR also includes patch version bump, but I can revert it if needed.