### PR TITLE
Upgrade snakeyaml (and other dependencies) to latest secure version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: friday
+  open-pull-requests-limit: 99
+

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
     implementation group: 'org.apache.ant', name: 'ant', version: '1.10.12'
     implementation group: 'com.beust', name: 'jcommander', version: '1.82'

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,9 @@ dependencies {
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginApiVersion
     testImplementation group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginApiVersion
 
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.0'
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.0'
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.8.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation group: 'org.apache.ant', name: 'ant', version: '1.10.12'
     implementation group: 'com.beust', name: 'jcommander', version: '1.82'
     implementation group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version: '1.15'
-    implementation group: 'org.yaml', name: 'snakeyaml', version: '1.26'
+    implementation group: 'org.yaml', name: 'snakeyaml', version: '1.32'
 
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginApiVersion
     testImplementation group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginApiVersion

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.0'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.6.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.8.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
 }
 


### PR DESCRIPTION
SnakeYaml < 1.31 has a few vulnerabilities reported against it which have been mitigated in `1.31`. Since config repos are "semi trusted" this is probably sensible for us to mitigate in the plugin.

This change
- resolves/removes noise from CVE-2022-25857 / CVE-2022-38749 / CVE-2022-38750 / CVE-2022-38751 / CVE-2022-38752
- enables dependabot to make these easier to deal with in future? 😀